### PR TITLE
fix python_tokenizer tok_name error

### DIFF
--- a/tokenizer/python/python_tokenizer.py
+++ b/tokenizer/python/python_tokenizer.py
@@ -1,7 +1,7 @@
 import parso
-from parso.python.tokenize import tokenize 
+from parso.python.tokenize import tokenize
 import json
-import sys 
+import sys
 
 file = open(sys.argv[1],'r')
 file_content = file.read()
@@ -9,12 +9,12 @@ file_content = file.read()
 tokens = []
 
 for token in tokenize(file_content, version_info=(3,6)):
-	tmp = dict()
-	tmp["line"]=(token.start_pos)[0];
-	tmp["char"]=((token.start_pos)[1])+1;
-	tmp["type"]=((str(token.type))[10:]).strip(")")
-	tmp["value"]=str(token.string)
-	tokens.append(tmp)
+        if (str(token.string) != ""):
+                tmp = dict()
+                tmp["line"]=(token.start_pos)[0];
+                tmp["char"]=((token.start_pos)[1])+1;
+                tmp["type"]=((str(token.type))[10:]).strip(")")
+                tmp["value"]=str(token.string)
+                tokens.append(tmp)
 
 print ( json.dumps(tokens, indent=4, sort_keys=True) )
-

--- a/tokenizer/python/python_tokenizer.py
+++ b/tokenizer/python/python_tokenizer.py
@@ -1,6 +1,6 @@
 import parso
 from parso.python.tokenize import tokenize
-from parso.python.token import tok_name
+from parso.python import token 
 import json
 import sys 
 
@@ -13,7 +13,7 @@ for token in tokenize(file_content, version_info=(3,6)):
 	tmp = dict()
 	tmp["line"]=(token.start_pos)[0];
 	tmp["char"]=((token.start_pos)[1])+1;
-	tmp["type"]=str(tok_name[token.type])
+	tmp["type"]=((str(token.type))[10:]).strip(")")
 	tmp["value"]=str(token.string)
 	tokens.append(tmp)
 

--- a/tokenizer/python/python_tokenizer.py
+++ b/tokenizer/python/python_tokenizer.py
@@ -1,6 +1,5 @@
 import parso
-from parso.python.tokenize import tokenize
-from parso.python import token 
+from parso.python.tokenize import tokenize 
 import json
 import sys 
 


### PR DESCRIPTION
I was testing python tokenizer and found that tok_name method in python_tokenizer.py was giving error. 
So corrected it by using alternate way of getting token type. 
Also removed empty value tokens.