### PR TITLE
Refactor tokenize_all and hash_all python files

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -103,6 +103,6 @@ def main():
                         my_cf.write("\n")
 
     print ("done")
-                            
+
 if __name__ == "__main__":
     main()

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -68,7 +68,7 @@ def main():
 
     sys.stdout.write("HASH ALL...")
     sys.stdout.flush()
-    
+
     # ===========================================================================
     # error checking
     course_dir=os.path.join(SUBMITTY_DATA_DIR,"courses",semester,course)
@@ -98,6 +98,6 @@ def main():
             hasher(args,my_tokenized_file,my_hashes_file)
 
     print("done")
-            
+
 if __name__ == "__main__":
     main()

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -19,6 +19,13 @@ with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
     OPEN_JSON = json.load(open_file)
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
 SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
+LANGUAGE_MAP = {
+    'plaintext': 'value',
+    'python': 'type',
+    'cpp': 'type',
+    'java': 'type',
+    'mips': 'type',
+}
 
 
 def parse_args():
@@ -32,6 +39,10 @@ def hasher(args,my_tokenized_file,my_hashes_file):
     with open(args.config_path) as lichen_config:
         lichen_config_data = json.load(lichen_config)
         language = lichen_config_data["language"]
+        if not token_key = LANGUAGE_MAP.get(language):
+            print("\n\nERROR: UNKNOWN HASHER\n\n")
+            exit(1)
+
         sequence_length = int(lichen_config_data["sequence_length"])
 
     if (sequence_length < 1):
@@ -42,40 +53,9 @@ def hasher(args,my_tokenized_file,my_hashes_file):
         with open(my_hashes_file,'w') as my_hf:
             tokens = json.load(my_tf)
             num = len(tokens)
-            for i in range(0,num-sequence_length):
-                foo=""
-                if language == "plaintext":
-                    for j in range(0,sequence_length):
-                        foo+=str(tokens[i+j].get("value"))
-
-                elif language == "python":
-                    for j in range(0,sequence_length):
-                        foo+=str(tokens[i+j].get("type"))
-
-                elif language == "cpp":
-                    for j in range(0,sequence_length):
-                        foo+=str(tokens[i+j].get("type"))
-
-                elif language == "java":
-                    for j in range(0,sequence_length):
-                        foo+=str(tokens[i+j].get("type"))
-
-                elif language == "mips":
-                    for j in range(0,sequence_length):
-                        foo+=str(tokens[i+j].get("type"))
-
-                else:
-                    print("\n\nERROR: UNKNOWN HASHER\n\n")
-                    exit(1)
-
-                hash_object = hashlib.md5(foo.encode())
-                hash_object_string=hash_object.hexdigest()
-                #FIXME: this truncation should be adjusted after more full-scale testing
-                #hash_object_string_truncated=hash_object_string[0:4]
-                hash_object_string_truncated=hash_object_string[0:8]
-                #my_hf.write(hash_object_string+"\n")
-                my_hf.write(hash_object_string_truncated+"\n")
-
+            #FIXME: this truncation should be adjusted after more full-scale testing
+            token_hashed_values = [ hashlib.mdf(''.join(tokens[x:x+sequence_length]).encode()).hexdigest[0:8] for x in range(0, num-sequence_length)]
+            my_hf.write('\n'.join(token_hashed_values))
 
 def main():
     args = parse_args()

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -50,7 +50,7 @@ def hasher(args,my_tokenized_file,my_hashes_file):
             token_values = [x.get(token_data[language]["token_value"]) for x in tokens]
             num = len(tokens)
             #FIXME: this truncation should be adjusted after more full-scale testing
-            token_hashed_values = [ (hashlib.md5(''.join(tokens[x:x+sequence_length]).encode()).hexdigest())[0:8] for x in range(0, num-sequence_length)]
+            token_hashed_values = [ (hashlib.md5(''.join(token_values[x:x+sequence_length]).encode()).hexdigest())[0:8] for x in range(0, num-sequence_length)]
             my_hf.write('\n'.join(token_hashed_values))
 
 def main():

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -31,11 +31,12 @@ def hasher(args,my_tokenized_file,my_hashes_file):
     with open(args.config_path) as lichen_config:
         lichen_config_data = json.load(lichen_config)
         language = lichen_config_data["language"]
-        if not token_key = LANGUAGE_MAP.get(language):
+        sequence_length = int(lichen_config_data["sequence_length"])
+
+    with open("data.jsonPath..") as token_data:
+        if not language in token_data:
             print("\n\nERROR: UNKNOWN HASHER\n\n")
             exit(1)
-
-        sequence_length = int(lichen_config_data["sequence_length"])
 
     if (sequence_length < 1):
         print ("ERROR! sequence_length must be >= 1")
@@ -44,6 +45,7 @@ def hasher(args,my_tokenized_file,my_hashes_file):
     with open(my_tokenized_file,'r',encoding='ISO-8859-1') as my_tf:
         with open(my_hashes_file,'w') as my_hf:
             tokens = json.load(my_tf)
+            token_values = [x.get(token_data["token_value"]) for x in tokens]
             num = len(tokens)
             #FIXME: this truncation should be adjusted after more full-scale testing
             token_hashed_values = [ hashlib.mdf(''.join(tokens[x:x+sequence_length]).encode()).hexdigest[0:8] for x in range(0, num-sequence_length)]

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -47,7 +47,7 @@ def hasher(args,my_tokenized_file,my_hashes_file):
     with open(my_tokenized_file,'r',encoding='ISO-8859-1') as my_tf:
         with open(my_hashes_file,'w') as my_hf:
             tokens = json.load(my_tf)
-            token_values = [x.get(token_data[language]["token_value"]) for x in tokens]
+            token_values = [str(x.get(token_data[language]["token_value"])) for x in tokens]
             num = len(tokens)
             #FIXME: this truncation should be adjusted after more full-scale testing
             token_hashed_values = [ (hashlib.md5(''.join(token_values[x:x+sequence_length]).encode()).hexdigest())[0:8] for x in range(0, num-sequence_length)]

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -33,7 +33,9 @@ def hasher(args,my_tokenized_file,my_hashes_file):
         language = lichen_config_data["language"]
         sequence_length = int(lichen_config_data["sequence_length"])
 
-    with open("data.jsonPath..") as token_data:
+    data_json_path = os.path.join(SUBMITTY_INSTALL_DIR, "Lichen", "bin", "data.json")
+    with open(data_json_path) as token_data_file:
+        token_data = json.load(token_data_file)
         if not language in token_data:
             print("\n\nERROR: UNKNOWN HASHER\n\n")
             exit(1)
@@ -45,10 +47,10 @@ def hasher(args,my_tokenized_file,my_hashes_file):
     with open(my_tokenized_file,'r',encoding='ISO-8859-1') as my_tf:
         with open(my_hashes_file,'w') as my_hf:
             tokens = json.load(my_tf)
-            token_values = [x.get(token_data["token_value"]) for x in tokens]
+            token_values = [x.get(token_data[language]["token_value"]) for x in tokens]
             num = len(tokens)
             #FIXME: this truncation should be adjusted after more full-scale testing
-            token_hashed_values = [ hashlib.mdf(''.join(tokens[x:x+sequence_length]).encode()).hexdigest[0:8] for x in range(0, num-sequence_length)]
+            token_hashed_values = [ (hashlib.md5(''.join(tokens[x:x+sequence_length]).encode()).hexdigest())[0:8] for x in range(0, num-sequence_length)]
             my_hf.write('\n'.join(token_hashed_values))
 
 def main():

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -19,14 +19,6 @@ with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
     OPEN_JSON = json.load(open_file)
 SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
 SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
-LANGUAGE_MAP = {
-    'plaintext': 'value',
-    'python': 'type',
-    'cpp': 'type',
-    'java': 'type',
-    'mips': 'type',
-}
-
 
 def parse_args():
     parser = argparse.ArgumentParser(description="")

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -36,10 +36,10 @@ do
 			ignore_submissions+=("$argument")
 		  	;;
 		esac
-	fi		
+	fi
 done
 
-/usr/local/submitty/Lichen/bin/concatenate_all.py  $semester $course $gradeable 
+/usr/local/submitty/Lichen/bin/concatenate_all.py  $semester $course $gradeable
 /usr/local/submitty/Lichen/bin/tokenize_all.py     $semester $course $gradeable  --${language}
 /usr/local/submitty/Lichen/bin/hash_all.py         $semester $course $gradeable  --window $window  --${language}
 

--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -30,7 +30,9 @@ def tokenize(args,my_concatenated_file,my_tokenized_file):
 
     language_token_data = dict()
 
-    with open("data.jsonPath..") as token_data:
+    data_json_path = os.path.join(SUBMITTY_INSTALL_DIR, "Lichen", "bin", "data.json")
+    with open(data_json_path, 'r') as token_data_file:
+        token_data = json.load(token_data_file)
         if not language in token_data:
             print("\n\nERROR: UNKNOWN TOKENIZER\n\n")
             exit(1)
@@ -38,10 +40,9 @@ def tokenize(args,my_concatenated_file,my_tokenized_file):
             language_token_data = token_data[language]
 
     tokenizer = os.path.join(SUBMITTY_INSTALL_DIR,"Lichen","bin", language_token_data["tokenizer"])
-    if language_token_data.get("input_as_argument"):
+    if not language_token_data.get("input_as_argument"):
         my_concatenated_file = f'< {my_concatenated_file}'
-    cli_args = ' '.join(language_token_data["command_args"]) if "command_args" in language_token_data else []
-                subprocess.call([tokenizer] + cli_args, stdin=infile, stdout=outfile)
+    cli_args = ' '.join(language_token_data["command_args"]) if "command_args" in language_token_data else ''
     command = f'{language_token_data["command_executable"]} {tokenizer} {cli_args} {my_concatenated_file} > {my_tokenized_file}'.strip()
     os.system(command)
 

--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -38,15 +38,12 @@ def tokenize(args,my_concatenated_file,my_tokenized_file):
             language_token_data = token_data[language]
 
     tokenizer = os.path.join(SUBMITTY_INSTALL_DIR,"Lichen","bin", language_token_data["tokenizer"])
-    if language_token_data.get("is_subprocess"):
-        # TODO: this isn't really necessary... Should probably use os.system for all
-        with open(my_concatenated_file,'r') as infile:
-            with open (my_tokenized_file,'w') as outfile:
-                cli_args = language_token_data["command_args"] if "command_args" in language_token_data else []
+    if language_token_data.get("input_as_argument"):
+        my_concatenated_file = f'< {my_concatenated_file}'
+    cli_args = ' '.join(language_token_data["command_args"]) if "command_args" in language_token_data else []
                 subprocess.call([tokenizer] + cli_args, stdin=infile, stdout=outfile)
-    else:
-        command = f'{language_token_data["command_executable"]} {tokenizer} {my_concatenated_file} > {my_tokenized_file}'
-        os.system(command)
+    command = f'{language_token_data["command_executable"]} {tokenizer} {cli_args} {my_concatenated_file} > {my_tokenized_file}'.strip()
+    os.system(command)
 
 def main():
     args = parse_args()

--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -28,51 +28,32 @@ def tokenize(args,my_concatenated_file,my_tokenized_file):
         lichen_config_data = json.load(lichen_config)
         language = lichen_config_data["language"]
 
-    if language == "plaintext":
-        tokenizer = os.path.join(SUBMITTY_INSTALL_DIR,"Lichen","bin","plaintext_tokenizer.out")
+    language_token_data = dict()
+
+    with open("data.jsonPath..") as token_data:
+        if not language in token_data:
+            print("\n\nERROR: UNKNOWN TOKENIZER\n\n")
+            exit(1)
+        else:
+            language_token_data = token_data[language]
+
+    tokenizer = os.path.join(SUBMITTY_INSTALL_DIR,"Lichen","bin", language_token_data["tokenizer"])
+    if language_token_data.get("is_subprocess"):
+        # TODO: this isn't really necessary... Should probably use os.system for all
         with open(my_concatenated_file,'r') as infile:
             with open (my_tokenized_file,'w') as outfile:
-                subprocess.call([tokenizer,"--ignore_newlines"],stdin=infile,stdout=outfile)
-
-    elif language == "python":
-        tokenizer = os.path.join(SUBMITTY_INSTALL_DIR,"Lichen","bin","python_tokenizer.py")
-        with open(my_concatenated_file,'r') as infile:
-            with open (my_tokenized_file,'w') as outfile:
-                command="python3 "+str(tokenizer)+" "+my_concatenated_file+" > "+my_tokenized_file
-                os.system(command)
-
-    elif language == "cpp":
-        tokenizer = os.path.join(SUBMITTY_INSTALL_DIR,"Lichen","bin","c_tokenizer.py")
-        with open(my_concatenated_file,'r') as infile:
-            with open (my_tokenized_file,'w') as outfile:
-                command="python "+str(tokenizer)+" "+my_concatenated_file+" > "+my_tokenized_file
-                os.system(command)
-
-    elif language == "java":
-        tokenizer = os.path.join(SUBMITTY_INSTALL_DIR,"Lichen","bin","java_tokenizer.py")
-        with open(my_concatenated_file,'r') as infile:
-            with open (my_tokenized_file,'w') as outfile:
-                command="python "+str(tokenizer)+" "+my_concatenated_file+" > "+my_tokenized_file
-                os.system(command)
-
-    elif language == "mips":
-        tokenizer = os.path.join(SUBMITTY_INSTALL_DIR,"Lichen","bin","mips_tokenizer.py")
-        with open(my_concatenated_file,'r') as infile:
-            with open (my_tokenized_file,'w') as outfile:
-                command="python3 "+str(tokenizer)+" "+my_concatenated_file+" > "+my_tokenized_file
-                os.system(command)
-
+                cli_args = language_token_data["command_args"] if "command_args" in language_token_data else []
+                subprocess.call([tokenizer] + cli_args, stdin=infile, stdout=outfile)
     else:
-        print("\n\nERROR: UNKNOWN TOKENIZER\n\n")
-        exit(1)
-
+        command = f'{language_token_data["command_executable"]} {tokenizer} {my_concatenated_file} > {my_tokenized_file}'
+        os.system(command)
 
 def main():
     args = parse_args()
 
     sys.stdout.write("TOKENIZE ALL...")
     sys.stdout.flush()
-    
+
     with open(args.config_path) as lichen_config:
         lichen_config_data = json.load(lichen_config)
         semester = lichen_config_data["semester"]
@@ -108,6 +89,5 @@ def main():
 
     print ("done")
 
-    
 if __name__ == "__main__":
     main()

--- a/install_lichen.sh
+++ b/install_lichen.sh
@@ -62,6 +62,7 @@ cp ${lichen_repository_dir}/tokenizer/c/c_tokenizer.py ${lichen_installation_dir
 cp ${lichen_repository_dir}/tokenizer/python/python_tokenizer.py ${lichen_installation_dir}/bin/python_tokenizer.py
 cp ${lichen_repository_dir}/tokenizer/java/java_tokenizer.py ${lichen_installation_dir}/bin/java_tokenizer.py
 cp ${lichen_repository_dir}/tokenizer/mips/mips_tokenizer.py ${lichen_installation_dir}/bin/mips_tokenizer.py
+cp ${lichen_repository_dir}/tokenizer/data.json ${lichen_installation_dir}/bin/data.json
 
 
 ########################################################################################################################

--- a/tokenizer/data.json
+++ b/tokenizer/data.json
@@ -1,0 +1,34 @@
+{
+  "plaintext": {
+    "tokenizer": "plaintext_tokenizer.out",
+    "is_subprocess": "true",
+    "command_args": [
+      "--ignore_newlines"
+    ],
+    "token_value": "value"
+  },
+  "python": {
+    "tokenizer": "python_tokenizer.py",
+    "is_subprocess": "false",
+    "command_executable": "python3",
+    "token_value": "type"
+  },
+  "cpp": {
+    "tokenizer": "c_tokenizer.py",
+    "is_subprocess": "false",
+    "command_executable": "python",
+    "token_value": "type"
+  },
+  "java": {
+    "tokenizer": "java_tokenizer.py",
+    "is_subprocess": "false",
+    "command_executable": "python",
+    "token_value": "type"
+  },
+  "mips": {
+    "tokenizer": "mips_tokenizer.py",
+    "is_subprocess": "false",
+    "command_executable": "python3",
+    "token_value": "type"
+  }
+}

--- a/tokenizer/data.json
+++ b/tokenizer/data.json
@@ -2,7 +2,7 @@
   "plaintext": {
     "tokenizer": "plaintext_tokenizer.out",
     "command_executable": "",
-    "input_as_argument": "false",
+    "input_as_argument": false,
     "command_args": [
       "--ignore_newlines"
     ],
@@ -11,25 +11,25 @@
   "python": {
     "tokenizer": "python_tokenizer.py",
     "command_executable": "python3",
-    "input_as_argument": "true",
+    "input_as_argument": true,
     "token_value": "type"
   },
   "cpp": {
     "tokenizer": "c_tokenizer.py",
     "command_executable": "python",
-    "input_as_argument": "true",
+    "input_as_argument": true,
     "token_value": "type"
   },
   "java": {
     "tokenizer": "java_tokenizer.py",
     "command_executable": "python",
-    "input_as_argument": "true",
+    "input_as_argument": true,
     "token_value": "type"
   },
   "mips": {
     "tokenizer": "mips_tokenizer.py",
     "command_executable": "python3",
-    "input_as_argument": "true",
+    "input_as_argument": true,
     "token_value": "type"
   }
 }

--- a/tokenizer/data.json
+++ b/tokenizer/data.json
@@ -1,7 +1,8 @@
 {
   "plaintext": {
     "tokenizer": "plaintext_tokenizer.out",
-    "is_subprocess": "true",
+    "command_executable": "",
+    "input_as_argument": "false",
     "command_args": [
       "--ignore_newlines"
     ],
@@ -9,26 +10,26 @@
   },
   "python": {
     "tokenizer": "python_tokenizer.py",
-    "is_subprocess": "false",
     "command_executable": "python3",
+    "input_as_argument": "true",
     "token_value": "type"
   },
   "cpp": {
     "tokenizer": "c_tokenizer.py",
-    "is_subprocess": "false",
     "command_executable": "python",
+    "input_as_argument": "true",
     "token_value": "type"
   },
   "java": {
     "tokenizer": "java_tokenizer.py",
-    "is_subprocess": "false",
     "command_executable": "python",
+    "input_as_argument": "true",
     "token_value": "type"
   },
   "mips": {
     "tokenizer": "mips_tokenizer.py",
-    "is_subprocess": "false",
     "command_executable": "python3",
+    "input_as_argument": "true",
     "token_value": "type"
   }
 }


### PR DESCRIPTION
Removes duplicate and unnecessary code from hash and tokenize python scripts. This abstracts data into a json specific for the given language. 

Line 53 in hash_all is a tad bit long... not the best readability so I can change to a normal for loop if suggested. 