### PR TITLE
[Feature:Plagiarism] common code & Individual Ranking

### DIFF
--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -8,9 +8,7 @@ the tokenized files.
 import argparse
 import os
 import json
-import subprocess
 import sys
-import json
 import hashlib
 
 CONFIG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'config')

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -72,7 +72,7 @@ void insert_others(const std::string &this_username,
                    std::map<Submission,std::set<int> > &others,
                    const std::map<Submission,std::vector<Sequence> > &matches) {
   for (std::map<Submission,std::vector<Sequence> >::const_iterator itr = matches.begin(); itr!=matches.end();itr++) {
-    for (int i = 0; i < itr->second.size(); i++) {
+    for (unsigned int i = 0; i < itr->second.size(); i++) {
       // don't include matches to this username
       if (this_username == itr->first.username)
         continue;
@@ -92,12 +92,12 @@ void convert(std::map<Submission,std::set<int> > &myset, nlohmann::json &obj, in
     int end = -1;
     std::set<int>::iterator itr2 = itr->second.begin();
     for (; itr2 != itr->second.end(); itr2++) {
-		start = *itr2;
-		end = start + sequence_length;
-		nlohmann::json range;
-		range["start"] = start;
-		range["end"] = end;
-		foo.push_back(range);
+  		start = *itr2;
+  		end = start + sequence_length;
+  		nlohmann::json range;
+  		range["start"] = start;
+  		range["end"] = end;
+  		foo.push_back(range);
     }
     me["matchingpositions"] = foo;
     obj.push_back(me);
@@ -176,7 +176,7 @@ int main(int argc, char* argv[]) {
         hash_counts[tmp][username].push_back(Sequence(username,version,count));
       }
       submission_length[Submission(username,version)]=count;
-    }    
+    }
   }
 
   std::cout << "finished loading" << std::endl;
@@ -190,14 +190,14 @@ int main(int argc, char* argv[]) {
   // label the parts of the file that match the provided code
   // user,version -> vector<position>
   std::map<Submission,std::vector<int> > provided;
-  
+
   // document the suspicious parts of this file,
   // user,version -> ( position -> ( other user,version -> std::vector<Sequence> ) )
   std::map<Submission,std::map<int,std::map<Submission, std::vector<Sequence> > > > suspicious;
 
   int my_counter = 0;
   int my_percent = 0;
-  
+
   // ---------------------------------------------------------------------------
   // walk over the structure containing all of the hashes identifying
   // common to many/all, provided code, suspicious matches, and unique code
@@ -213,7 +213,7 @@ int main(int argc, char* argv[]) {
     if (count > threshold) {
       // common to many/all
       for (std::map<std::string,std::vector<Sequence> >::iterator itr2 = itr->second.begin(); itr2 != itr->second.end(); itr2++) {
-        for (int i = 0; i < itr2->second.size(); i++) {
+        for (unsigned int i = 0; i < itr2->second.size(); i++) {
           common[itr2->second[i].submission].insert(itr2->second[i].position);
         }
       }
@@ -221,16 +221,16 @@ int main(int argc, char* argv[]) {
       // suspicious matches
       for (std::map<std::string,std::vector<Sequence> >::iterator itr2 = itr->second.begin(); itr2 != itr->second.end(); itr2++) {
         std::string username = itr2->first;
-        for (int i = 0; i < itr2->second.size(); i++) {
+        for (unsigned int i = 0; i < itr2->second.size(); i++) {
           assert (itr2->second[i].submission.username == username);
           int version = itr2->second[i].submission.version;
           int position = itr2->second[i].position;
 
           std::map<Submission, std::vector<Sequence> > matches;
-          
+
           for (std::map<std::string,std::vector<Sequence> >::iterator itr3 = itr->second.begin(); itr3 != itr->second.end(); itr3++) {
             std::string match_username = itr3->first;
-            for (int j = 0; j < itr3->second.size(); j++) {
+            for (unsigned int j = 0; j < itr3->second.size(); j++) {
               int match_version = itr3->second[j].submission.version;
               Submission ms(match_username,match_version);
               matches[ms].push_back(itr3->second[j]);
@@ -248,7 +248,7 @@ int main(int argc, char* argv[]) {
   // ---------------------------------------------------------------------------
   // prepare a sorted list of all users sorted by match percent
   std::vector<std::pair<Submission,float> > ranking;
-    
+
   for (std::map<Submission,std::map<int,std::map<Submission,std::vector<Sequence> > > >::iterator itr = suspicious.begin();
        itr != suspicious.end(); itr++) {
     int total = submission_length[itr->first];
@@ -263,22 +263,22 @@ int main(int argc, char* argv[]) {
     ranking.push_back(std::make_pair(itr->first,percent));
 
     // prepare the ranges of suspicious matching tokens
-    int range_start=-1;
-    int range_end=-1;
+    int range_start = -1;
+    int range_end = -1;
     std::map<Submission, std::set<int> > others;
-    std::map<int,std::map<Submission,std::vector<Sequence> > >::iterator itr2 = itr->second.begin();
+    std::map<int, std::map<Submission, std::vector<Sequence> > >::iterator itr2 = itr->second.begin();
 
     for (; itr2 != itr->second.end(); itr2++) {
     	range_start = itr2->first;
     	range_end = range_start + sequence_length;
-    	insert_others(username,others,itr2->second);
-    	std::map<std::string,nlohmann::json> info_data;
-    	info_data["start"]=nlohmann::json(range_start);
-    	info_data["end"]=nlohmann::json(range_end);
-    	info_data["type"]=nlohmann::json(std::string("match"));
+    	insert_others(username, others, itr2->second);
+    	std::map<std::string, nlohmann::json> info_data;
+    	info_data["start"] = nlohmann::json(range_start);
+    	info_data["end"] = nlohmann::json(range_end);
+    	info_data["type"] = nlohmann::json(std::string("match"));
     	nlohmann::json obj;
-    	convert(others,obj, sequence_length);
-    	info_data["others"]=obj;
+    	convert(others, obj, sequence_length);
+    	info_data["others"] = obj;
     	info.push_back(info_data);
     	others.clear();
     }
@@ -289,19 +289,19 @@ int main(int argc, char* argv[]) {
     boost::filesystem::create_directories(matches_dir);
     std::string matches_file = matches_dir+"/matches.json";
     std::ofstream ostr(matches_file);
-    assert (ostr.good());
+    assert(ostr.good());
     ostr << match_data.dump(4) << std::endl;
   }
 
   std::set<std::string> users_already_ranked;
-  
+
   // save the rankings to a file
   std::string ranking_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/";
   std::string ranking_file = ranking_dir+gradeable+".txt";
   boost::filesystem::create_directories(ranking_dir);
   std::ofstream ranking_ostr(ranking_file);
   std::sort(ranking.begin(),ranking.end(),ranking_sorter);
-  for (int i = 0; i < ranking.size(); i++) {
+  for (unsigned int i = 0; i < ranking.size(); i++) {
     std::string username = ranking[i].first.username;
     if (users_already_ranked.insert(username).second != false) {
       // print each username at most once, only if insert was
@@ -313,7 +313,7 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  
+
   // ---------------------------------------------------------------------------
   std::cout << "done" << std::endl;
 }

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -264,7 +264,7 @@ int main(int argc, char* argv[]) {
         std::vector<HashLocation>::iterator itr = occurences_itr->second.begin();
         for (; itr != occurences_itr->second.end(); ++itr) {
           
-          if (occurences.size() > threshold) {
+          if (occurences.size() > (unsigned int)threshold) {
             // if the number of students with matching code is more 
             // than the threshold, it is considered common code
             submission_itr->addCommonMatch(hash_itr->second, *itr);
@@ -326,9 +326,8 @@ int main(int argc, char* argv[]) {
         std::vector<nlohmann::json> matchingpositions;
         nlohmann::json position;
         position["start"] = matching_positions_itr->location;
-        position["end"] = matching_positions_itr->location + sequence_length;
+        position["end"] = matching_positions_itr->location + sequence_length - 1;
         matchingpositions.push_back(position);
-        other["matchingpositions"] = matchingpositions;
         
         // search for all matching positions of the suspicious match in other submissions
         if (location_itr->second.size() > 1) {
@@ -337,26 +336,28 @@ int main(int argc, char* argv[]) {
           for (; matching_positions_itr != location_itr->second.end(); ++matching_positions_itr) {
             // keep iterating and editing the same object until a we get to a different submission
             if (matching_positions_itr->student != other["username"] || matching_positions_itr->version != other["version"]) {
+              std::cout << "We are in the inner if statement!" << std::endl;
               // found a different one, we push the old one and start over
               others.push_back(other);
 
               matchingpositions.clear();
               other["username"] = matching_positions_itr->student;
               other["version"] = matching_positions_itr->version;
-              position["start"] = matching_positions_itr->location;
-              position["end"] = matching_positions_itr->location + sequence_length;
+              other["matchingpositions"] = matchingpositions;
             }
             position["start"] = matching_positions_itr->location;
-            position["end"] = matching_positions_itr->location + sequence_length;
+            position["end"] = matching_positions_itr->location + sequence_length - 1;
             matchingpositions.push_back(position);
           }
         }
+        
+        other["matchingpositions"] = matchingpositions;
         others.push_back(other);
       }
 
       nlohmann::json info;
       info["start"] = location_itr->first;
-      info["end"] = location_itr->first + sequence_length;
+      info["end"] = location_itr->first + sequence_length - 1;
       info["type"] = "match";
       info["others"] = others;
 
@@ -385,9 +386,8 @@ int main(int argc, char* argv[]) {
         std::vector<nlohmann::json> matchingpositions;
         nlohmann::json position;
         position["start"] = matching_positions_itr->location;
-        position["end"] = matching_positions_itr->location + sequence_length;
+        position["end"] = matching_positions_itr->location + sequence_length - 1;
         matchingpositions.push_back(position);
-        other["matchingpositions"] = matchingpositions;
         
         // search for all matching positions of the suspicious match in other submissions
         if (location_itr->second.size() > 1) {
@@ -402,20 +402,20 @@ int main(int argc, char* argv[]) {
               matchingpositions.clear();
               other["username"] = matching_positions_itr->student;
               other["version"] = matching_positions_itr->version;
-              position["start"] = matching_positions_itr->location;
-              position["end"] = matching_positions_itr->location + sequence_length;
+              other["matchingpositions"] = matchingpositions;
             }
             position["start"] = matching_positions_itr->location;
-            position["end"] = matching_positions_itr->location + sequence_length;
+            position["end"] = matching_positions_itr->location + sequence_length - 1;
             matchingpositions.push_back(position);
           }
         }
+        other["matchingpositions"] = matchingpositions;
         others.push_back(other);
       }
 
       nlohmann::json info;
       info["start"] = location_itr->first;
-      info["end"] = location_itr->first + sequence_length;
+      info["end"] = location_itr->first + sequence_length - 1;
       info["type"] = "common";
       info["others"] = others;
 
@@ -482,6 +482,7 @@ int main(int argc, char* argv[]) {
       my_percent = int((my_counter / float(all_submissions.size())) * 100);
       std::cout << "merging: " << my_percent << "% complete" << std::endl;
     }
+
   }
   std::cout << "done merging and writing matches files" << std::endl;
 

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -86,7 +86,7 @@ public:
   const std::map<location_in_submission, std::set<HashLocation> >& getCommonMatches() const {
     return common_matches;
   }
-  const std::unordered_map<std::string, std::unoredered_map<int, int> >& getStudentsMatched() const {
+  const std::unordered_map<std::string, std::unordered_map<int, int> >& getStudentsMatched() const {
     return students_matched;
   }
   unsigned int getNumHashes() const { return hashes.size(); }
@@ -103,7 +103,7 @@ private:
 
   // a container to keep track of all the students this submission 
   // matched and the number of matching hashes per submission
-  std::unordered_map<std::string, std::unoredered_map<int, int> > students_matched;
+  std::unordered_map<std::string, std::unordered_map<int, int> > students_matched;
 };
 
 
@@ -567,18 +567,19 @@ int main(int argc, char* argv[]) {
        submission_itr != all_submissions.end(); ++submission_itr) {
     
     // create the directory and a file to write into
-    std::string ranking_student_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/"+submission_itr->student()+"/"+submission_itr->version()+"/";
-    std::string ranking_student_file = ranking_student_dir+submission_itr->student()+"_"+submission_itr->version+".txt";
+    std::string ranking_student_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/"
+                                      +submission_itr->student()+"/"+std::to_string(submission_itr->version())+"/";
+    std::string ranking_student_file = ranking_student_dir+submission_itr->student()+"_"+std::to_string(submission_itr->version())+".txt";
     boost::filesystem::create_directories(ranking_student_dir);
     std::ofstream ranking_student_ostr(ranking_student_file);
 
     // find and sort the other submissions it matches with
     std::vector<StudentRanking> student_ranking;
-    std::unordered_map<std::string, std::unoredered_map<int, int> > matches = submission_itr->getStudentsMatched();
-    for (std::unordered_map<std::string, std::unoredered_map<int, int> >::const_iterator matches_itr; 
-         matches_itr = matches.begin(); matches_itr != matches.end(); ++matches_itr) {
+    std::unordered_map<std::string, std::unordered_map<int, int> > matches = submission_itr->getStudentsMatched();
+    for (std::unordered_map<std::string, std::unordered_map<int, int> >::const_iterator matches_itr = matches.begin(); 
+         matches_itr != matches.end(); ++matches_itr) {
       
-      for (std::unoredered_map<int, int>::const_iterator version_itr = matches_itr->second.begin();
+      for (std::unordered_map<int, int>::const_iterator version_itr = matches_itr->second.begin();
            version_itr != matches_itr->second.end(); ++version_itr) {
 
         // the percent match is currently calculated using the number of hashes that match between this

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -568,7 +568,7 @@ int main(int argc, char* argv[]) {
     
     // create the directory and a file to write into
     std::string ranking_student_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/"
-                                      +gradeable+submission_itr->student()+"/"+std::to_string(submission_itr->version())+"/";
+                                      +gradeable+"/"+submission_itr->student()+"/"+std::to_string(submission_itr->version())+"/";
     std::string ranking_student_file = ranking_student_dir+submission_itr->student()+"_"+std::to_string(submission_itr->version())+".txt";
     boost::filesystem::create_directories(ranking_student_dir);
     std::ofstream ranking_student_ostr(ranking_student_file);

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -130,7 +130,7 @@ void incrementEndPositionsForMatches(nlohmann::json &matches) {
 // in a small number of other files (but not most or all).
 bool ranking_sorter(const StudentRanking &a, const StudentRanking &b) {
   return a.percent > b.percent ||
-        (a.percent == b.percent && a.student > b.student);
+        (a.percent == b.percent && a.student < b.student);
 }
 
 // ===================================================================================
@@ -394,7 +394,7 @@ int main(int argc, char* argv[]) {
   for (std::vector<Submission>::iterator submission_itr = all_submissions.begin();
        submission_itr != all_submissions.end(); ++submission_itr) {
 
-    float percentMatch = (100.0 * submission_itr->getSuspiciousMatches().size()) / all_hashes.size();
+    float percentMatch = (100.0 * submission_itr->getSuspiciousMatches().size()) / submission_itr->getHashes().size();
 
     std::unordered_map<std::string, std::pair<int, float> >::iterator highest_matches_itr
         = highest_matches.find(submission_itr->student());

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -515,7 +515,7 @@ int main(int argc, char* argv[]) {
   // Create a general summary of rankings of users by percentage match
 
   // create a single file of students ranked by highest percentage of code plagiarised
-  std::string ranking_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/"+gradeable;
+  std::string ranking_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/"+gradeable+"/";
   std::string ranking_file = ranking_dir+"overall_ranking.txt";
   boost::filesystem::create_directories(ranking_dir);
   std::ofstream ranking_ostr(ranking_file);

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -13,59 +13,107 @@
 
 #include "nlohmann/json.hpp"
 
-using namespace std;
-
-// ===================================================================================
-// helper classes
-
-// represents the location of a hash within 
-// a unique student and version pair
-struct HashLocation {
-  HashLocation(const string &s, int v, location_in_submission l) : student(s), version(v), location(l) {}
-  string student;
-  int version;
-  location_in_submission location;
-};
-
-// represents a unique student-version pair, all its 
-// hashes, and other submissions with those hashes
-class Submission {
-public:
-  Submission(const string &s, int v) : student_(s), version_(v) {}
-  const string & student() const { return student_; }
-  int version() const { return version_; }
-  void addHash(const hash &h, location_in_submission l) { hashed.push_back(make_pair(h, l)); }
-  const vector<pair<hash, location_in_submission>> & getHashes() const { return hashes; }
-  void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location) {
-    map<location_in_submission, vector<HashLocation>>::iterator itr =  suspicious_matches.find(location);
-    if (itr != suspicious_matches.end()) {
-      // location already exists in the map, so we just append the location to the vector
-      suspicious_matches[location].push_back(matching_location);
-    } else {
-      // intialize the vector and add the location
-      vector<HashLocation> v();
-      v.push_back(matching_location);
-      suspicious_matches[location] = v;
-    }
-  }
-
-private:
-  string student_;
-  int version_;
-  vector<pair<hash, location_in_submission>> hashes;
-  map<location_in_submission, vector<HashLocation>> suspicious_matches;
-};
-
 
 // ===================================================================================
 // helper typedefs
 
 typedef int location_in_submission;
-typedef string hash;
+typedef std::string hash;
 
 
 // ===================================================================================
+// helper classes
+
+// represents the location of a hash within
+// a unique student and version pair
+struct HashLocation {
+  HashLocation(const std::string &s, int v, location_in_submission l) : student(s), version(v), location(l) {}
+  std::string student;
+  int version;
+  location_in_submission location;
+};
+
+// represents a unique student-version pair, all its
+// hashes, and other submissions with those hashes
+class Submission {
+public:
+  Submission(const std::string &s, int v) : student_(s), version_(v) {}
+  const std::string & student() const { return student_; }
+  int version() const { return version_; }
+  void addHash(const hash &h, location_in_submission l) { hashes.push_back(make_pair(h, l)); }
+  const std::vector<std::pair<hash, location_in_submission>> & getHashes() const { return hashes; }
+  void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location) {
+    std::map<location_in_submission, std::set<HashLocation>>::iterator itr =  suspicious_matches.find(location);
+    if (itr != suspicious_matches.end()) {
+      // location already exists in the map, so we just append the location to the vector
+      suspicious_matches[location].insert(matching_location);
+    } else {
+      // intialize the vector and add the location
+      std::set<HashLocation> s;
+      s.insert(matching_location);
+      suspicious_matches[location] = s;
+    }
+  }
+  const std::map<location_in_submission, std::set<HashLocation> >& getSuspiciousMatches() const {
+    return suspicious_matches;
+  }
+
+private:
+  std::string student_;
+  int version_;
+  std::vector<std::pair<hash, location_in_submission> > hashes;
+  std::map<location_in_submission, std::set<HashLocation> > suspicious_matches;
+};
+
+// ===================================================================================
 // helper functions
+
+bool operator < (const HashLocation &hl1, const HashLocation &hl2) {
+  return hl1.student > hl2.student ||
+         (hl1.student == hl2.student && hl1.version < hl2.version) ||
+         (hl1.student == hl2.student && hl1.version == hl2.version && hl1.location < hl2.location);
+}
+
+
+// ensures that all of the regions in the two parameters are adjacent
+bool matchingPositionsAreAdjacent(const nlohmann::json &first, const nlohmann::json &second) {
+  // they can't all be adjacent if there are an unequal number between the two lists
+  if (first.size() != second.size()) {
+    return false;
+  }
+
+  nlohmann::json::const_iterator itr1 = first.begin();
+  nlohmann::json::const_iterator itr2 = second.begin();
+  // iterate over each matching submission
+  for (; itr1 != first.end() && itr2 != second.end(); itr1++, itr2++) {
+    // the number of matches must be the same
+    if ((*itr1)["matchingpositions"].size() != (*itr2)["matchingpositions"].size()) {
+      return false;
+    }
+
+    nlohmann::json::const_iterator itr3 = (*itr1)["matchingpositions"].begin();
+    nlohmann::json::const_iterator itr4 = (*itr2)["matchingpositions"].begin();
+    // iterate over each matching position in the submission
+    for (; itr3 != (*itr1)["matchingpositions"].end() && itr4 != (*itr2)["matchingpositions"].end(); itr3++, itr4++) {
+      if ((*itr3)["end"].get<int>() + 1 != (*itr4)["end"].get<int>()) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+
+// increments the end position for each of the matches in the json provided
+void incrementEndPositionsForMatches(nlohmann::json &matches) {
+  nlohmann::json::iterator itr = matches.begin();
+  for (; itr != matches.end(); itr++) {
+    nlohmann::json::iterator itr2 = (*itr)["matchingpositions"].begin();
+    for (; itr2 != (*itr)["matchingpositions"].end(); itr2++) {
+      (*itr2)["end"] = (*itr2)["end"].get<int>() + 1;
+    }
+  }
+}
 
 
 // TODO: remake functions
@@ -201,9 +249,9 @@ int main(int argc, char* argv[]) {
   // loop over all submissions and populate the all_hashes and all_submissions structures
 
   // Stores all the hashes and their locations across all submissions
-  unordered_map<hash, vector<HashLocation>> all_hashes;
+  std::unordered_map<hash, std::vector<HashLocation>> all_hashes;
   // Stores all submissions
-  vector<Submission> all_submissions;
+  std::vector<Submission> all_submissions;
 
   // loop over all users
   boost::filesystem::directory_iterator end_iter;
@@ -211,7 +259,7 @@ int main(int argc, char* argv[]) {
     boost::filesystem::path username_path = dir_itr->path();
     assert (is_directory(username_path));
     std::string username = dir_itr->path().filename().string();
-    
+
     // loop over all versions
     for (boost::filesystem::directory_iterator username_itr( username_path ); username_itr != end_iter; ++username_itr) {
       boost::filesystem::path version_path = username_itr->path();
@@ -248,24 +296,20 @@ int main(int argc, char* argv[]) {
   int my_percent = 0;
 
   // ---------------------------------------------------------------------------
-  
-  //unordered_map<hash, vector<HashLocation>> all_hashes;
-  //vector<Submission> all_submissions;
 
-  // walk over every Submission 
-  for (vector<Submission>::iterator submission_itr = all_submissions.begin(); 
+  // walk over every Submission
+  for (std::vector<Submission>::iterator submission_itr = all_submissions.begin();
        submission_itr != all_submissions.end(); ++submission_itr) {
-    
+
     // walk over every hash in that submission
-    vector<pair<hash, location_in_submission>>::const_iterator hash_itr = submission_itr->getHashes().begin();
+    std::vector<std::pair<hash, location_in_submission>>::const_iterator hash_itr = submission_itr->getHashes().begin();
     for (; hash_itr != submission_itr->getHashes().end(); ++hash_itr) {
-      
+
       // look up that hash in the all_hashes table, and see which other occurences of that hash in other submisions
-      vector<HashLocation> occurences = all_hashes[hash_itr->first]->second; // TODO: Optimize?
-      vector<HashLocation>::iterator occurences_itr = occurences.begin();
+      std::vector<HashLocation> occurences = all_hashes[hash_itr->first]; // TODO: Optimize?
+      std::vector<HashLocation>::iterator occurences_itr = occurences.begin();
       for (; occurences_itr != occurences.end(); ++occurences_itr) {
-        if (occurences_itr->name != submission_itr->student()) {
-          // SUS MATCH. 
+        if (occurences_itr->student != submission_itr->student()) {
           submission_itr->addSuspiciousMatch(hash_itr->second, *occurences_itr);
         }
       }
@@ -275,52 +319,85 @@ int main(int argc, char* argv[]) {
   std::cout << "finished walking" << std::endl;
 
   // ---------------------------------------------------------------------------
-  // prepare a sorted list of all users sorted by match percent
-  std::vector<std::pair<Submission,float> > ranking;
 
   my_counter = 0;
   my_percent = 0;
   std::cout << "merging regions and writing matches files..." << std::endl;
-  for (std::map<Submission,std::map<int,std::map<Submission,std::vector<Sequence> > > >::iterator itr = suspicious.begin();
-       itr != suspicious.end(); itr++) {
-    int total = submission_length[itr->first];
-    int overlap = itr->second.size();
-    float percent = float(overlap)/float(total);
 
-    std::vector<nlohmann::json> info;
+  // Loop over all of the submissions, writing a JSON file for each one if it has suspicious matches
+  for (std::vector<Submission>::iterator submission_itr = all_submissions.begin();
+       submission_itr != all_submissions.end(); ++submission_itr) {
+    // If there are no suspicious matches, don't create a JSON file
+    if (submission_itr->getSuspiciousMatches().size() == 0) {
+      continue;
+    }
+    // holds the JSON file to be written
+    std::vector<nlohmann::json> result;
 
-    std::string username = itr->first.username;
-    int version = itr->first.version;
+    // all of the suspicious matches for this submission
+    std::map<location_in_submission, std::set<HashLocation> > suspicious_matches = submission_itr->getSuspiciousMatches();
 
-    ranking.push_back(std::make_pair(itr->first,percent));
+    // loop over each of the suspicious locations in the current submission
+    for (std::map<location_in_submission, std::set<HashLocation> >::const_iterator location_itr
+         =suspicious_matches.begin(); location_itr != suspicious_matches.end(); ++location_itr) {
 
-    // prepare the ranges of suspicious matching tokens
-    int range_start = -1;
-    int range_end = -1;
-    std::map<Submission, std::set<int> > others;
+      // stores matches of hash locations across other submssions in the class
+      std::vector<nlohmann::json> others;
 
-    for (std::map<int, std::map<Submission, std::vector<Sequence> > >::iterator itr2 = itr->second.begin();
-         itr2 != itr->second.end(); itr2++) {
-    	range_start = itr2->first;
-    	range_end = range_start + sequence_length;
-    	insert_others(username, others, itr2->second);
-    	std::map<std::string, nlohmann::json> info_data;
-    	info_data["start"] = nlohmann::json(range_start);
-    	info_data["end"] = nlohmann::json(range_end);
-    	info_data["type"] = nlohmann::json(std::string("match"));
-    	nlohmann::json obj;
-    	convert(others, obj, sequence_length);
-    	info_data["others"] = obj;
-    	info.push_back(info_data);
-    	others.clear();
+      { // generate a specific element of the "others" vector
+        // set the variables to their initial values
+        std::set<HashLocation>::const_iterator matching_positions_itr = location_itr->second.begin();
+        nlohmann::json other;
+        other["username"] = matching_positions_itr->student;
+        other["version"] = matching_positions_itr->version;
+        std::vector<nlohmann::json> matchingpositions;
+        nlohmann::json position;
+        position["start"] = matching_positions_itr->location;
+        position["end"] = matching_positions_itr->location + sequence_length;
+        matchingpositions.push_back(position);
+        other["matchingpositions"] = matchingpositions;
+        // if there's more than one matching location, we should add more
+        if (location_itr->second.size() > 1) {
+          ++matching_positions_itr;
+          // loop over all of the other matching positions
+          for (; matching_positions_itr != location_itr->second.end(); ++matching_positions_itr) {
+            if (matching_positions_itr->student != other["username"] || matching_positions_itr->version != other["version"]) {
+              // we move onto the next user so the matching positions for this user are complete
+              others.push_back(other);
+
+              matchingpositions.clear();
+              other["username"] = matching_positions_itr->student;
+              other["version"] = matching_positions_itr->version;
+              position["start"] = matching_positions_itr->location;
+              position["end"] = matching_positions_itr->location + sequence_length;
+            }
+            position["start"] = matching_positions_itr->location;
+            position["end"] = matching_positions_itr->location + sequence_length;
+            matchingpositions.push_back(position);
+          }
+        }
+        others.push_back(other);
+      }
+
+      nlohmann::json info;
+      info["start"] = location_itr->first;
+      info["end"] = location_itr->first + sequence_length;
+      info["type"] = "match";
+      info["others"] = others;
+
+      result.push_back(info);
     }
 
+
+    // prepare a sorted list of all users sorted by match percent
+    std::vector<std::pair<Submission,float> > ranking;
+
     // Merge matching regions:
-    if (info.size() > 0) { // check to make sure that there are more than 1 positions (if it's 1, we can't merge anyway)
+    if (result.size() > 0) { // check to make sure that there are more than 1 positions (if it's 1, we can't merge anyway)
       // loop through all positions
-      for (unsigned int position = 1; position < info.size(); position++) {
-        nlohmann::json* prevPosition = &info[position - 1];
-        nlohmann::json* currPosition = &info[position];
+      for (unsigned int position = 1; position < result.size(); position++) {
+        nlohmann::json* prevPosition = &result[position - 1];
+        nlohmann::json* currPosition = &result[position];
         if ((*currPosition)["end"].get<int>() == (*prevPosition)["end"].get<int>() + 1) { // check whether they are next to each other
           bool canBeMerged = true;
           nlohmann::json::iterator prevPosItr = (*prevPosition)["others"].begin();
@@ -346,7 +423,7 @@ int main(int argc, char* argv[]) {
             // increment end positions for each element
             incrementEndPositionsForMatches((*prevPosition)["others"]);
 
-            info.erase(info.begin() + position);
+            result.erase(result.begin() + position);
             position--;
           }
         }
@@ -354,8 +431,9 @@ int main(int argc, char* argv[]) {
     }
 
     // save the file with matches per user
-    nlohmann::json match_data = info;
-    std::string matches_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/matches/"+gradeable+"/"+username+"/"+std::to_string(version);
+    nlohmann::json match_data = result;
+    std::string matches_dir = "/var/local/submitty/courses/"+semester+"/"+course
+        +"/lichen/matches/"+gradeable+"/"+submission_itr->student()+"/"+std::to_string(submission_itr->version());
     boost::filesystem::create_directories(matches_dir);
     std::string matches_file = matches_dir+"/matches.json";
     std::ofstream ostr(matches_file);
@@ -363,32 +441,36 @@ int main(int argc, char* argv[]) {
     ostr << match_data.dump(4) << std::endl;
 
     my_counter++;
-    if (int((my_counter / float(suspicious.size())) * 100) > my_percent) {
-      my_percent = int((my_counter / float(suspicious.size())) * 100);
+    if (int((my_counter / float(all_submissions.size())) * 100) > my_percent) {
+      my_percent = int((my_counter / float(all_submissions.size())) * 100);
       std::cout << "merging: " << my_percent << "% complete" << std::endl;
     }
   }
   std::cout << "done merging and writing matches files" << std::endl;
 
-  std::set<std::string> users_already_ranked;
 
-  // save the rankings to a file
-  std::string ranking_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/";
-  std::string ranking_file = ranking_dir+gradeable+".txt";
-  boost::filesystem::create_directories(ranking_dir);
-  std::ofstream ranking_ostr(ranking_file);
-  std::sort(ranking.begin(),ranking.end(),ranking_sorter);
-  for (unsigned int i = 0; i < ranking.size(); i++) {
-    std::string username = ranking[i].first.username;
-    if (users_already_ranked.insert(username).second != false) {
-      // print each username at most once, only if insert was
-      // successful (not already in the set)
-      ranking_ostr
-        << std::setw(6) << std::setprecision(2) << std::fixed << 100.0*ranking[i].second << "%   "
-        << std::setw(15) << std::left << ranking[i].first.username << " "
-        << std::setw(3) << std::right << ranking[i].first.version << std::endl;
-    }
-  }
+
+
+
+  // std::set<std::string> users_already_ranked;
+  //
+  // // save the rankings to a file
+  // std::string ranking_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/";
+  // std::string ranking_file = ranking_dir+gradeable+".txt";
+  // boost::filesystem::create_directories(ranking_dir);
+  // std::ofstream ranking_ostr(ranking_file);
+  // std::sort(ranking.begin(),ranking.end(),ranking_sorter);
+  // for (unsigned int i = 0; i < ranking.size(); i++) {
+  //   std::string username = ranking[i].first.username;
+  //   if (users_already_ranked.insert(username).second != false) {
+  //     // print each username at most once, only if insert was
+  //     // successful (not already in the set)
+  //     ranking_ostr
+  //       << std::setw(6) << std::setprecision(2) << std::fixed << 100.0*ranking[i].second << "%   "
+  //       << std::setw(15) << std::left << ranking[i].first.username << " "
+  //       << std::setw(3) << std::right << ranking[i].first.version << std::endl;
+  //   }
+  // }
 
 
   // ---------------------------------------------------------------------------

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -70,12 +70,12 @@ public:
 
     if (itr != common_matches.end()) {
       // location already exists in the map, so we just append the location to the set
-      suspicious_matches[location].insert(matching_location);
+      common_matches[location].insert(matching_location);
     } else {
       // intialize the set and add the location
       std::set<HashLocation> s;
       s.insert(matching_location);
-      suspicious_matches[location] = s;
+      common_matches[location] = s;
     }
   }
   const std::map<location_in_submission, std::set<HashLocation> >& getSuspiciousMatches() const {
@@ -144,7 +144,7 @@ void incrementEndPositionsForMatches(nlohmann::json &matches) {
     nlohmann::json::iterator itr2 = (*itr)["matchingpositions"].begin();
     nlohmann::json::iterator itr3 = ++((*itr)["matchingpositions"].begin());
     for (; itr3 != (*itr)["matchingpositions"].end();) {
-      if ((*itr2)["end"].get<int>() + 1 > (*itr3)["start"]) {
+      if ((*itr2)["end"].get<int>() >= (*itr3)["start"]) {
         (*itr2)["end"] = (*itr3)["end"].get<int>();
         itr3 = (*itr)["matchingpositions"].erase(itr3);
       }
@@ -342,18 +342,19 @@ int main(int argc, char* argv[]) {
         // search for all matching positions of the suspicious match in other submissions
         if (location_itr->second.size() > 1) {
           ++matching_positions_itr;
+          
           // loop over all of the other matching positions
           for (; matching_positions_itr != location_itr->second.end(); ++matching_positions_itr) {
+            
             // keep iterating and editing the same object until a we get to a different submission
             if (matching_positions_itr->student != other["username"] || matching_positions_itr->version != other["version"]) {
-              std::cout << "We are in the inner if statement!" << std::endl;
               // found a different one, we push the old one and start over
+              other["matchingpositions"] = matchingpositions;
               others.push_back(other);
 
               matchingpositions.clear();
               other["username"] = matching_positions_itr->student;
               other["version"] = matching_positions_itr->version;
-              other["matchingpositions"] = matchingpositions;
             }
             position["start"] = matching_positions_itr->location;
             position["end"] = matching_positions_itr->location + sequence_length - 1;
@@ -402,23 +403,26 @@ int main(int argc, char* argv[]) {
         // search for all matching positions of the suspicious match in other submissions
         if (location_itr->second.size() > 1) {
           ++matching_positions_itr;
+          
           // loop over all of the other matching positions
           for (; matching_positions_itr != location_itr->second.end(); ++matching_positions_itr) {
+            
             // keep iterating and editing the same object until a we get to a different submission
             if (matching_positions_itr->student != other["username"] || matching_positions_itr->version != other["version"]) {
               // found a different one, we push the old one and start over
+              other["matchingpositions"] = matchingpositions;
               others.push_back(other);
 
               matchingpositions.clear();
               other["username"] = matching_positions_itr->student;
               other["version"] = matching_positions_itr->version;
-              other["matchingpositions"] = matchingpositions;
             }
             position["start"] = matching_positions_itr->location;
             position["end"] = matching_positions_itr->location + sequence_length - 1;
             matchingpositions.push_back(position);
           }
         }
+
         other["matchingpositions"] = matchingpositions;
         others.push_back(other);
       }
@@ -437,6 +441,7 @@ int main(int argc, char* argv[]) {
     // ---------------------------------------------------------------------------
     // Done creating the JSON file/objects, now we merge them to shrink them in size
 
+    /*
     // Merge matching regions:
     if (result.size() > 0) { // check to make sure that there are more than 1 positions (if it's 1, we can't merge anyway)
       // loop through all positions
@@ -474,7 +479,7 @@ int main(int argc, char* argv[]) {
           }
         }
       }
-    }
+    }*/
 
     // save the file with matches per user
     nlohmann::json match_data = result;

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -43,7 +43,8 @@ public:
   void addHash(const hash &h, location_in_submission l) { hashes.push_back(make_pair(h, l)); }
   const std::vector<std::pair<hash, location_in_submission>> & getHashes() const { return hashes; }
   void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location) {
-    std::map<location_in_submission, std::set<HashLocation>>::iterator itr =  suspicious_matches.find(location);
+    std::map<location_in_submission, std::set<HashLocation>>::iterator itr = suspicious_matches.find(location);
+
     if (itr != suspicious_matches.end()) {
       // location already exists in the map, so we just append the location to the vector
       suspicious_matches[location].insert(matching_location);
@@ -270,7 +271,6 @@ int main(int argc, char* argv[]) {
 
       // create a submission object and load to the main submission structure
       Submission submission(username, version);
-      all_submissions.push_back(submission);
 
       // load the hashes sequences from this submission
       boost::filesystem::path hash_file = version_path;
@@ -283,6 +283,8 @@ int main(int argc, char* argv[]) {
         all_hashes[input_hash].push_back(HashLocation(username, version, location));
         submission.addHash(input_hash, location);
       }
+
+      all_submissions.push_back(submission);
     }
   }
 
@@ -313,6 +315,11 @@ int main(int argc, char* argv[]) {
           submission_itr->addSuspiciousMatch(hash_itr->second, *occurences_itr);
         }
       }
+    }
+    my_counter++;
+    if (int((my_counter / float(all_submissions.size())) * 100) > my_percent) {
+      my_percent = int((my_counter / float(all_submissions.size())) * 100);
+      std::cout << "hash walk: " << my_percent << "% complete" << std::endl;
     }
   }
 
@@ -390,7 +397,7 @@ int main(int argc, char* argv[]) {
 
 
     // prepare a sorted list of all users sorted by match percent
-    std::vector<std::pair<Submission,float> > ranking;
+    // std::vector<std::pair<Submission,float> > ranking;
 
     // Merge matching regions:
     if (result.size() > 0) { // check to make sure that there are more than 1 positions (if it's 1, we can't merge anyway)

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -515,8 +515,8 @@ int main(int argc, char* argv[]) {
   // Create a general summary of rankings of users by percentage match
 
   // create a single file of students ranked by highest percentage of code plagiarised
-  std::string ranking_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/";
-  std::string ranking_file = ranking_dir+gradeable+".txt";
+  std::string ranking_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/"+gradeable;
+  std::string ranking_file = ranking_dir+"overall_ranking.txt";
   boost::filesystem::create_directories(ranking_dir);
   std::ofstream ranking_ostr(ranking_file);
 
@@ -568,7 +568,7 @@ int main(int argc, char* argv[]) {
     
     // create the directory and a file to write into
     std::string ranking_student_dir = "/var/local/submitty/courses/"+semester+"/"+course+"/lichen/ranking/"
-                                      +submission_itr->student()+"/"+std::to_string(submission_itr->version())+"/";
+                                      +gradeable+submission_itr->student()+"/"+std::to_string(submission_itr->version())+"/";
     std::string ranking_student_file = ranking_student_dir+submission_itr->student()+"_"+std::to_string(submission_itr->version())+".txt";
     boost::filesystem::create_directories(ranking_student_dir);
     std::ofstream ranking_student_ostr(ranking_student_file);
@@ -585,7 +585,7 @@ int main(int argc, char* argv[]) {
         // the percent match is currently calculated using the number of hashes that match between this
         // submission and the other submission, over the total number of hashes this submission has.
         // In other words, the percentage is how much of this submission's code was plgairised from the other.
-        float percent = float(version_itr->second) / submission_itr->getNumHashes();
+        float percent = 100.0 * float(version_itr->second) / submission_itr->getNumHashes();
         student_ranking.push_back(StudentRanking(matches_itr->first, version_itr->first, percent));
       }
     }


### PR DESCRIPTION
The changes in this PR are made to move the computation of ranking for each student from the page backend to the `compare_hashes.cpp` program.
Moving the computation to the C++ and creating those files ahead of time instead of looping over the individual students' `matches.json` files will save time  in the rendering of the plagiarism results page when two student codes are displayed next to each other.

Due to a series of merge conflicts, PR #27 was closed.  The contents of that PR are included in this PR.  As a result, this PR adds checking to identify common code.