### PR TITLE
[Feature:Plagiarism] Add support for regex directories

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -44,6 +44,12 @@ def main():
         regex_expressions = lichen_config_data["regex"].split(',')
         regex_dirs = lichen_config_data["regex_dirs"]
 
+    for e in regex_expressions:
+        # Check for backwards crawling
+        if ".." in e:
+            print('ERROR! Invalid path component ".." in regex')
+            exit(1)
+
     # =========================================================================
     # error checking
     course_dir = os.path.join(SUBMITTY_DATA_DIR, "courses", semester, course)
@@ -97,11 +103,6 @@ def main():
                         if regex_expressions[0] != "":
                             files_filtered = []
                             for e in regex_expressions:
-                                # Check for backwards crawling
-                                if ".." in e:
-                                    print('ERROR! Invalid path component ".." in regex')
-                                    exit(1)
-
                                 files_filtered.extend(fnmatch.filter(files, e.strip()))
                             files = files_filtered
 

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -97,6 +97,11 @@ def main():
                         if regex_expressions[0] != "":
                             files_filtered = []
                             for e in regex_expressions:
+                                # Check for backwards crawling
+                                if ".." in e:
+                                    print('ERROR! Invalid path component ".." in regex')
+                                    exit(1)
+
                                 files_filtered.extend(fnmatch.filter(files, e.strip()))
                             files = files_filtered
 

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -62,7 +62,7 @@ def main():
 
         # more error checking
         if not os.path.isdir(submission_dir):
-            print("ERROR! ", submission_dir, f" is not a valid gradeable ", dir, " directory")
+            print("ERROR! ", submission_dir, " is not a valid gradeable ", dir, " directory")
             exit(1)
 
         # =========================================================================

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -41,7 +41,7 @@ def main():
         gradeable = lichen_config_data["gradeable"]
 
         # this assumes regex is seperated by a ','
-        expressions = lichen_config_data["regex"].split(',')
+        regex_expressions = lichen_config_data["regex"].split(',')
         regex_dirs = lichen_config_data["regex_dirs"]
 
     # =========================================================================
@@ -58,6 +58,10 @@ def main():
         os.makedirs(concatenated_dir)
 
     for dir in regex_dirs:
+        if dir not in ["submissions", "results", "checkout"]:
+            print("ERROR! ", dir, " is not a valid input directory for Lichen")
+            exit(1)
+
         submission_dir = os.path.join(course_dir, dir, gradeable)
 
         # more error checking
@@ -90,9 +94,9 @@ def main():
                         # Determine if regex should be used (no regex provided
                         # is equivalent to selecting all files)
                         files = sorted(my_files)
-                        if expressions[0] != "":
+                        if regex_expressions[0] != "":
                             files_filtered = []
-                            for e in expressions:
+                            for e in regex_expressions:
                                 files_filtered.extend(fnmatch.filter(files, e.strip()))
                             files = files_filtered
 

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -174,10 +174,8 @@ int main(int argc, char* argv[]) {
   std::string semester = config_file_json.value("semester","ERROR");
   std::string course = config_file_json.value("course","ERROR");
   std::string gradeable = config_file_json.value("gradeable","ERROR");
-  std::string sequence_length_str = config_file_json.value("sequence_length","1");
-  int sequence_length = std::stoi(sequence_length_str);
-  std::string threshold_str = config_file_json.value("threshold","5");
-  int threshold = std::stoi(threshold_str);
+  int sequence_length = config_file_json.value("sequence_length",1);
+  int threshold = config_file_json.value("threshold",5);
 
   assert (sequence_length >= 1);
   assert (threshold >= 2);


### PR DESCRIPTION
### Old Behavior
The `concatenate_all.py` file was only scraping files from the `submissions` directory of a course to be tokenized and processed in the matching algorithm.

### New Behavior
The `submissions`, `results`, `checkout` directories of a course are scraped based on the specifications in the gradeable plagiarism configuration, and the specified regular expressions are applied to only concatenate files that conform to them.
Additionally, separators with filenames were added to the concatenated files, which make looking at the results easier when multiple files are concatenated per submission.

### Other Information
This PR goes hand-in-hand with https://github.com/Submitty/Submitty/pull/6612, which implements the frontend UI inputs and the backend to create the appropriate fields in the `config.json` file which this PR relies on.