### PR TITLE
[Documentation:Plagiarism] Add PR template to Lichen

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
 ### Please check if the PR fulfills these requirements:
 
-* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
 * [ ] Tests for the changes have been added/updated (if possible)
 * [ ] Documentation has been updated/added if relevant
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Please check if the PR fulfills these requirements:
+
+* [ ] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
+* [ ] Tests for the changes have been added/updated (if possible)
+* [ ] Documentation has been updated/added if relevant
+
+### What is the current behavior?
+<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
+
+### What is the new behavior?
+
+### Other information?
+<!-- Is this a breaking change? -->
+<!-- How did you test -->


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:
* [x] The PR title and message follows our [guidelines](https://submitty.org/developer/how_to_contribute)
* [x] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant

### What is the current behavior?
The body of PR's made on the Lichen repo is empty by default, so the contents of PR's are not standardized. 

### What is the new behavior?
Project contributors will automatically see the template's contents (identical to the template used on the main Submitty repo) in the body of a pull request.