### PR TITLE
[Feature:Plagiarism] Implement ignored submissions

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -39,6 +39,7 @@ def main():
         semester = lichen_config_data["semester"]
         course = lichen_config_data["course"]
         gradeable = lichen_config_data["gradeable"]
+        users_to_ignore = lichen_config_data["ignore_submissions"]
 
         # this assumes regex is seperated by a ','
         regex_expressions = lichen_config_data["regex"].split(',')
@@ -79,6 +80,8 @@ def main():
         # walk the subdirectories
         for user in sorted(os.listdir(submission_dir)):
             if not os.path.isdir(os.path.join(submission_dir, user)):
+                continue
+            elif user in users_to_ignore:
                 continue
             for version in sorted(os.listdir(os.path.join(submission_dir, user))):
                 if not os.path.isdir(os.path.join(submission_dir, user, version)):


### PR DESCRIPTION
### What is the current behavior?
The "ignore submissions" feature is not implemented or supported in the Lichen code. All submissions from all the course users are concatenated, tokenized, and hashed.

### What is the new behavior?
The submissions of the users listed under "ignore_submissions" in the `config.json` for a gradeable are not concatenated, and as a result, not tokenized, hashed and them compared in `compare_hashes.cpp`. 

### Other information?
This PR is related to, but independent from the Submitty PR https://github.com/Submitty/Submitty/pull/6666, since the "ignore_submissions" field exists in the `config.json` in the current Submitty master branch. The Submitty PR writes user id's to ignore into that field in the config, and everything works normally if nothing is written into it. 
