### PR TITLE
[Refactor:Plagiarism] Redo file structure

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -22,7 +22,7 @@ def getConcatFilesInDir(input_dir, regex_patterns):
     for my_dir, _dirs, my_files in os.walk(input_dir):
         # Determine if regex should be used (blank regex is equivalent to selecting all files)
         files = sorted(my_files)
-        if regex_expressions[0] != "":
+        if regex_patterns[0] != "":
             files_filtered = []
             for e in regex_patterns:
                 files_filtered.extend(fnmatch.filter(files, e.strip()))
@@ -88,7 +88,7 @@ def main():
     # loop through and concatenate the selected files for each user in this gradeable
 
     for dir in regex_dirs:
-        gradeable_path = os.path.join(datapath, semester, course, dir, gradeable)
+        gradeable_path = os.path.join(args.datapath, semester, course, dir, gradeable)
         # loop over each user
         for user in sorted(os.listdir(gradeable_path)):
             user_path = os.path.join(gradeable_path, user)
@@ -113,7 +113,6 @@ def main():
                 with open(output_file_path, "a") as output_file:
                     concatenated_contents = getConcatFilesInDir(version_path, regex_patterns)
                     output_file.write(concatenated_contents)
-
 
     # ==========================================================================
     # iterate over all of the created submissions, checking to see if they are empty

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -134,7 +134,7 @@ def main():
 
     # ==========================================================================
     end_time = time.time()
-    print("done in " + str(end_time - start_time) + " seconds")
+    print("done in " + "%.0f" % (end_time - start_time) + " seconds")
 
 
 if __name__ == "__main__":

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -55,7 +55,7 @@ def main():
     sys.stdout.write("CONCATENATE ALL...")  # don't want a newline here so can't use print
     sys.stdout.flush()
 
-    config_path = args.basepath + '/config.json'
+    config_path = os.path.join(args.basepath, "config.json")
     if not os.path.isfile(config_path):
         print(f"Error: invalid config path provided ({config_path})")
         exit(1)
@@ -130,7 +130,8 @@ def main():
     # concatenate provided code
     with open(os.path.join(args.basepath, "provided_code",
                            "submission.concatenated"), "w") as file:
-        file.write(getConcatFilesInDir(os.path.join(args.basepath, "provided_code", "files"), regex_patterns))
+        provided_code_files = os.path.join(args.basepath, "provided_code", "files")
+        file.write(getConcatFilesInDir(provided_code_files, regex_patterns))
 
     # ==========================================================================
     end_time = time.time()

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -120,7 +120,7 @@ def main():
     for user in os.listdir(os.path.join(args.basepath, "users")):
         user_path = os.path.join(args.basepath, "users", user)
         for version in os.listdir(user_path):
-            version_path = user_path = os.path.join(user_path, version)
+            version_path = os.path.join(user_path, version)
             my_concatenated_file = os.path.join(version_path, "submission.concatenated")
             with open(my_concatenated_file, "r+") as my_cf:
                 if my_cf.read() == "":

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -8,52 +8,73 @@ import argparse
 import os
 import json
 import sys
-import shutil
+import time
 import fnmatch
-
-CONFIG_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'config')
-with open(os.path.join(CONFIG_PATH, 'submitty.json')) as open_file:
-    OPEN_JSON = json.load(open_file)
-SUBMITTY_DATA_DIR = OPEN_JSON['submitty_data_dir']
-SUBMITTY_INSTALL_DIR = OPEN_JSON['submitty_install_dir']
 
 IGNORED_FILES = [
     ".submit.timestamp"
 ]
 
 
+# returns a string containing the contents of the files which match the regex in the specified dir
+def getConcatFilesInDir(input_dir, regex_patterns):
+    result = ""
+    for my_dir, _dirs, my_files in os.walk(input_dir):
+        # Determine if regex should be used (blank regex is equivalent to selecting all files)
+        files = sorted(my_files)
+        if regex_expressions[0] != "":
+            files_filtered = []
+            for e in regex_patterns:
+                files_filtered.extend(fnmatch.filter(files, e.strip()))
+            files = files_filtered
+
+        for my_file in files:
+            # exclude any files we have ignored for all submissions
+            if my_file in IGNORED_FILES:
+                continue
+            absolute_path = os.path.join(my_dir, my_file)
+            # print a separator & filename
+            with open(absolute_path, encoding='ISO-8859-1') as tmp:
+                result += f"=============== {my_file} ===============\n"
+                # append the contents of the file
+                result += tmp.read() + "\n"
+    return result
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="")
-    parser.add_argument("config_path")
+    parser.add_argument("basepath")
+    parser.add_argument("datapath")
     return parser.parse_args()
 
 
 def main():
+    start_time = time.time()
     args = parse_args()
 
-    sys.stdout.write("CONCATENATE ALL...")
+    sys.stdout.write("CONCATENATE ALL...")  # don't want a newline here so can't use print
     sys.stdout.flush()
 
-    with open(args.config_path) as lichen_config:
-        lichen_config_data = json.load(lichen_config)
-        semester = lichen_config_data["semester"]
-        course = lichen_config_data["course"]
-        gradeable = lichen_config_data["gradeable"]
-        users_to_ignore = lichen_config_data["ignore_submissions"]
-
-        # this assumes regex is seperated by a ','
-        regex_expressions = lichen_config_data["regex"].split(',')
-        regex_dirs = lichen_config_data["regex_dirs"]
-
-    # ==========================================================================
-    # error checking
-    course_dir = os.path.join(SUBMITTY_DATA_DIR, "courses", semester, course)
-    if not os.path.isdir(course_dir):
-        print("ERROR! ", course_dir, " is not a valid course directory")
+    config_path = args.basepath + '/config.json'
+    if not os.path.isfile(config_path):
+        print(f"Error: invalid config path provided ({config_path})")
         exit(1)
 
-    for e in regex_expressions:
-        # Check for backwards crawling
+    with open(config_path) as config_file:
+        config = json.load(config_file)
+
+    semester = config["semester"]
+    course = config["course"]
+    gradeable = config["gradeable"]
+    users_to_ignore = config["ignore_submissions"]
+    regex_patterns = config["regex"].split(',')
+    regex_dirs = config["regex_dirs"]
+
+    # ==========================================================================
+    # Error checking
+
+    # Check for backwards crawling
+    for e in regex_patterns:
         if ".." in e:
             print('ERROR! Invalid path component ".." in regex')
             exit(1)
@@ -64,99 +85,57 @@ def main():
             exit(1)
 
     # ==========================================================================
-    # create the directory
-    concatenated_dir = os.path.join(course_dir, "lichen", "concatenated", gradeable)
-    if not os.path.isdir(concatenated_dir):
-        os.makedirs(concatenated_dir)
-
-    # ==========================================================================
-    count_total_files = 0
+    # loop through and concatenate the selected files for each user in this gradeable
 
     for dir in regex_dirs:
-        submission_dir = os.path.join(course_dir, dir, gradeable)
-
-        # more error checking
-        if not os.path.isdir(submission_dir):
-            print("ERROR! ", submission_dir, " is not a valid gradeable ", dir, " directory")
-            exit(1)
-
-        # =========================================================================
-        # walk the subdirectories
-        for user in sorted(os.listdir(submission_dir)):
-            if not os.path.isdir(os.path.join(submission_dir, user)):
+        gradeable_path = os.path.join(datapath, semester, course, dir, gradeable)
+        # loop over each user
+        for user in sorted(os.listdir(gradeable_path)):
+            user_path = os.path.join(gradeable_path, user)
+            if not os.path.isdir(user_path):
                 continue
             elif user in users_to_ignore:
                 continue
-            for version in sorted(os.listdir(os.path.join(submission_dir, user))):
-                if not os.path.isdir(os.path.join(submission_dir, user, version)):
+
+            # loop over each version
+            for version in sorted(os.listdir(user_path)):
+                version_path = os.path.join(user_path, version)
+                if not os.path.isdir(version_path):
                     continue
 
-                # -----------------------------------------------------------------
-                # concatenate all files for this submissison into a single file
-                my_concatenated_dir = os.path.join(concatenated_dir, user, version)
-                if not os.path.isdir(my_concatenated_dir):
-                    os.makedirs(my_concatenated_dir)
-                my_concatenated_file = os.path.join(my_concatenated_dir, "submission.concatenated")
+                output_file_path = os.path.join(args.basepath, user,
+                                                version, "submission.concatenated")
 
-                with open(my_concatenated_file, 'a') as my_cf:
-                    # loop over all files in all subdirectories
-                    base_path = os.path.join(submission_dir, user, version)
-                    for my_dir, _dirs, my_files in os.walk(base_path):
-                        # Determine if regex should be used (no regex provided
-                        # is equivalent to selecting all files)
-                        files = sorted(my_files)
-                        if regex_expressions[0] != "":
-                            files_filtered = []
-                            for e in regex_expressions:
-                                files_filtered.extend(fnmatch.filter(files, e.strip()))
-                            files = files_filtered
+                if not os.path.exists(os.path.dirname(output_file_path)):
+                    os.makedirs(os.path.dirname(output_file_path))
 
-                        for my_file in files:
-                            # exclude any files we have ignored for all submissions
-                            if my_file in IGNORED_FILES:
-                                continue
-                            absolute_path = os.path.join(my_dir, my_file)
-                            # print a separator & filename
-                            my_cf.write(f"=============== {my_file} ===============\n")
-                            with open(absolute_path, encoding='ISO-8859-1') as tmp:
-                                # append the contents of the file
-                                my_cf.write(tmp.read())
-                                my_cf.write("\n")
-                            count_total_files += 1
+                # append to concatenated file
+                with open(output_file_path, "a") as output_file:
+                    concatenated_contents = getConcatFilesInDir(version_path, regex_patterns)
+                    output_file.write(concatenated_contents)
+
+
     # ==========================================================================
-    # iterate over all of the created submissions, checking to see if they are
+    # iterate over all of the created submissions, checking to see if they are empty
     # and adding a message to the top if so (to differentiate empty files from errors in the UI)
-    for user in os.listdir(concatenated_dir):
-        for version in os.listdir(os.path.join(concatenated_dir, user)):
-            my_concatenated_file = os.path.join(concatenated_dir,
-                                                user, version, "submission.concatenated")
+    for user in os.listdir(os.path.join(args.basepath, "users")):
+        user_path = os.path.join(args.basepath, "users", user)
+        for version in os.listdir(user_path):
+            version_path = user_path = os.path.join(user_path, version)
+            my_concatenated_file = os.path.join(version_path, "submission.concatenated")
             with open(my_concatenated_file, "r+") as my_cf:
                 if my_cf.read() == "":
                     my_cf.write("Error: No files matched provided regex in selected directories")
 
     # ==========================================================================
-    # concatenate any files in the provided_code directory
-    provided_code_path = os.path.join(course_dir, "lichen", "provided_code", gradeable)
-    output_dir = os.path.join(course_dir, "lichen", "concatenated",
-                              gradeable, "provided_code", "provided_code")
-    output_file = os.path.join(output_dir, "submission.concatenated")
-
-    if os.path.isdir(provided_code_path) and len(os.listdir(provided_code_path)) != 0:
-        # If the directory already exists, delete it and make a new one
-        if os.path.isdir(output_dir):
-            shutil.rmtree(output_dir)
-        os.makedirs(output_dir)
-
-        with open(output_file, 'w') as of:
-            # Loop over all of the provided files and concatenate them
-            for file in sorted(os.listdir(provided_code_path)):
-                with open(os.path.join(provided_code_path, file), encoding='ISO-8859-1') as tmp:
-                    # append the contents of the file
-                    of.write(tmp.read())
+    # concatenate provided code
+    with open(os.path.join(args.basepath, "provided_code",
+                           "submission.concatenated"), "w") as file:
+        file.write(getConcatFilesInDir(os.path.join(args.basepath, "provided_code", "files")), [])
 
     # ==========================================================================
-    print("done")
-    print(f"{count_total_files} files concatenated")
+    end_time = time.time()
+    print("done in " + str(end_time - start_time) + " seconds")
 
 
 if __name__ == "__main__":

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -103,7 +103,7 @@ def main():
                 if not os.path.isdir(version_path):
                     continue
 
-                output_file_path = os.path.join(args.basepath, user,
+                output_file_path = os.path.join(args.basepath, "users", user,
                                                 version, "submission.concatenated")
 
                 if not os.path.exists(os.path.dirname(output_file_path)):
@@ -130,7 +130,7 @@ def main():
     # concatenate provided code
     with open(os.path.join(args.basepath, "provided_code",
                            "submission.concatenated"), "w") as file:
-        file.write(getConcatFilesInDir(os.path.join(args.basepath, "provided_code", "files")), [])
+        file.write(getConcatFilesInDir(os.path.join(args.basepath, "provided_code", "files"), regex_patterns))
 
     # ==========================================================================
     end_time = time.time()

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -79,6 +79,12 @@ def main():
             my_hashes_file = os.path.join(my_dir, "hashes.txt")
             hasher(lichen_config_data, my_tokenized_file, my_hashes_file)
 
+    # ===========================================================================
+    # hash the provided code
+    provided_code_tokenized = os.path.join(args.basepath, "provided_code", "tokens.json")
+    provided_code_hashed = os.path.join(args.basepath, "provided_code", "hashes.txt")
+    hasher(lichen_config_data, provided_code_tokenized, provided_code_hashed)
+
     # ==========================================================================
     end_time = time.time()
     print("done in " + "%.0f" % (end_time - start_time) + " seconds")

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -37,15 +37,17 @@ def hasher(lichen_config_data, my_tokenized_file, my_hashes_file):
     with open(my_tokenized_file, 'r', encoding='ISO-8859-1') as my_tf:
         with open(my_hashes_file, 'w') as my_hf:
             tokens = json.load(my_tf)
-            token_values = [str(x.get(token_data[language]["token_value"]))
-                            for x in tokens]
-            num = len(tokens)
-            # FIXME: this truncation should be adjusted after testing
-            token_hashed_values = [(hashlib.md5(''.join(
-                token_values[x:x+sequence_length]).encode())
-                .hexdigest())[0:8] for x in range(0, num-sequence_length+1)]
+            # write empty hashes file if the tokens file was empty (such as
+            # when there is no provided code)
+            if tokens is not None:
+                token_values = [str(x[token_data[language]["token_value"]]) for x in tokens]
+                num = len(tokens)
+                # FIXME: this truncation should be adjusted after testing
+                token_hashed_values = [(hashlib.md5(''.join(
+                    token_values[x:x+sequence_length]).encode())
+                    .hexdigest())[0:8] for x in range(0, num-sequence_length+1)]
 
-            my_hf.write('\n'.join(token_hashed_values))
+                my_hf.write('\n'.join(token_hashed_values))
 
 
 def main():
@@ -75,6 +77,7 @@ def main():
             if not os.path.isdir(my_dir):
                 continue
 
+            print(my_dir)
             my_tokenized_file = os.path.join(my_dir, "tokens.json")
             my_hashes_file = os.path.join(my_dir, "hashes.txt")
             hasher(lichen_config_data, my_tokenized_file, my_hashes_file)

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -8,6 +8,7 @@ the tokenized files.
 import argparse
 import os
 import json
+import time
 import sys
 import hashlib
 
@@ -48,6 +49,7 @@ def hasher(lichen_config_data, my_tokenized_file, my_hashes_file):
 
 
 def main():
+    start_time = time.time()
     args = parse_args()
 
     with open(os.path.join(args.basepath, "config.json")) as lichen_config:
@@ -77,7 +79,9 @@ def main():
             my_hashes_file = os.path.join(my_dir, "hashes.txt")
             hasher(lichen_config_data, my_tokenized_file, my_hashes_file)
 
-    print("done")
+    # ==========================================================================
+    end_time = time.time()
+    print("done in " + "%.0f" % (end_time - start_time) + " seconds")
 
 
 if __name__ == "__main__":

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -77,7 +77,6 @@ def main():
             if not os.path.isdir(my_dir):
                 continue
 
-            print(my_dir)
             my_tokenized_file = os.path.join(my_dir, "tokens.json")
             my_hashes_file = os.path.join(my_dir, "hashes.txt")
             hasher(lichen_config_data, my_tokenized_file, my_hashes_file)

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -31,7 +31,7 @@ mkdir -p "${basepath}/other_gradeables"
 mkdir -p "${basepath}/users"
 
 # run all of the modules and exit if an error occurs
-./concatenate_all.py  "${basepath}" "${datapath}" || exit 1
+./concatenate_all.py  $basepath $datapath || exit 1
 ./tokenize_all.py     $basepath || exit 1
 ./hash_all.py         $basepath || exit 1
 ./compare_hashes.out  $basepath || exit 1

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # This script is the startup script for Lichen.  It accepts a single path to a
 # directory containing a config file and creates the necessary output directories
 # as appropriate, relative to the provided path.  It is possible to run this script
@@ -22,10 +24,10 @@ fi
 rm -rf "${basepath}/logs"
 rm -rf "${basepath}/other_gradeables"
 rm -rf "${basepath}/users"
-rm "${basepath}/overall_ranking.txt"
-rm "${basepath}/provided_code/submission.concatenated"
-rm "${basepath}/provided_code/tokens.json"
-rm "${basepath}/provided_code/hashes.txt"
+rm -f "${basepath}/overall_ranking.txt"
+rm -f "${basepath}/provided_code/submission.concatenated"
+rm -f "${basepath}/provided_code/tokens.json"
+rm -f "${basepath}/provided_code/hashes.txt"
 
 # create these directories if they don't already exist
 mkdir -p "${basepath}/logs"
@@ -34,8 +36,13 @@ mkdir -p "${basepath}/provided_code/files"
 mkdir -p "${basepath}/other_gradeables"
 mkdir -p "${basepath}/users"
 
+log_file="${basepath}/logs/lichen_job_output.txt"
+
+cd $(dirname "${0}")
+
 # run all of the modules and exit if an error occurs
-./concatenate_all.py  $basepath $datapath || exit 1
-./tokenize_all.py     $basepath || exit 1
-./hash_all.py         $basepath || exit 1
-./compare_hashes.out  $basepath || exit 1
+echo "Beginning Lichen run: $(date +"%Y-%m-%d %H:%M:%S")" >> $log_file 2>&1
+./concatenate_all.py  $basepath $datapath >> $log_file 2>&1 || exit 1
+./tokenize_all.py     $basepath           >> $log_file 2>&1 || exit 1
+./hash_all.py         $basepath           >> $log_file 2>&1 || exit 1
+./compare_hashes.out  $basepath           >> $log_file 2>&1 || exit 1

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -36,6 +36,9 @@ mkdir -p "${basepath}/provided_code/files"
 mkdir -p "${basepath}/other_gradeables"
 mkdir -p "${basepath}/users"
 
+# the default is r-x and we need PHP to be able to write if edits are made to the provided code
+chmod g=rwxs "${basepath}/provided_code/files"
+
 log_file="${basepath}/logs/lichen_job_output.txt"
 
 cd $(dirname "${0}")

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -12,10 +12,16 @@ datapath=$2 # holds the path to a directory conatining courses and their data
             # (probably /var/local/submitty/courses on Submitty)
 
 # kill the script if there is no config file
-# if [ ! -f "${basepath}/config.json" ]; then
-#     echo "Unable to find config.json in provided directory"
-# 		exit 1
-# fi
+if [ ! -f "${basepath}/config.json" ]; then
+    echo "Unable to find config.json in provided directory"
+		exit 1
+fi
+
+# delete any previous run results
+# TODO: determine if any caching should occur
+rm -rf "${basepath}/logs"
+rm -rf "${basepath}/other_gradeables"
+rm -rf "${basepath}/users"
 
 # create these directories if they don't already exist
 mkdir -p "${basepath}/logs"

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -22,6 +22,10 @@ fi
 rm -rf "${basepath}/logs"
 rm -rf "${basepath}/other_gradeables"
 rm -rf "${basepath}/users"
+rm "${basepath}/overall_ranking.txt"
+rm "${basepath}/provided_code/submission.concatenated"
+rm "${basepath}/provided_code/tokens.json"
+rm "${basepath}/provided_code/hashes.txt"
 
 # create these directories if they don't already exist
 mkdir -p "${basepath}/logs"

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -6,20 +6,24 @@
 # TODO: Assert permissions, as necessary
 
 basepath=$1 # holds the path to a directory containing a config for this gradeable
+datapath=$2 # holds the path to a directory conatining courses and their data
+            # (probably /var/local/submitty/courses on Submitty)
 
 # kill the script if there is no config file
-if [! -f "${basepath}/config.json" ]; then
+if [ ! -f "${basepath}/config.json" ]; then
     echo "Unable to find config.json in provided directory"
 		exit 1
 fi
 
-# provided_code should already exist if the user wishes to run with provided code
+# create these directories if they don't already exist
 mkdir -p "${basepath}/logs"
+mkdir -p "${basepath}/provided_code"
+mkdir -p "${basepath}/provided_code/files"
 mkdir -p "${basepath}/other_gradeables"
 mkdir -p "${basepath}/users"
 
-
-/usr/local/submitty/Lichen/bin/concatenate_all.py  $basepath
-#/usr/local/submitty/Lichen/bin/tokenize_all.py     $basepath
-#/usr/local/submitty/Lichen/bin/hash_all.py         $basepath
-#/usr/local/submitty/Lichen/bin/compare_hashes.out  $basepath
+# run all of the modules and exit if an error occurs
+/usr/local/submitty/Lichen/bin/concatenate_all.py  $basepath $datapath || exit 1
+#/usr/local/submitty/Lichen/bin/tokenize_all.py     $basepath || exit 1
+#/usr/local/submitty/Lichen/bin/hash_all.py         $basepath || exit 1
+#/usr/local/submitty/Lichen/bin/compare_hashes.out  $basepath || exit 1

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -27,5 +27,5 @@ mkdir -p "${basepath}/users"
 # run all of the modules and exit if an error occurs
 ./concatenate_all.py  "${basepath}" "${datapath}" || exit 1
 ./tokenize_all.py     $basepath || exit 1
-#hash_all.py         $basepath || exit 1
-#compare_hashes.out  $basepath || exit 1
+./hash_all.py         $basepath || exit 1
+./compare_hashes.out  $basepath || exit 1

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -6,14 +6,16 @@
 # TODO: Assert permissions, as necessary
 
 basepath=$1 # holds the path to a directory containing a config for this gradeable
+            # (probably .../lichen/gradeable/<unique number>/ on Submitty)
+
 datapath=$2 # holds the path to a directory conatining courses and their data
             # (probably /var/local/submitty/courses on Submitty)
 
 # kill the script if there is no config file
-if [ ! -f "${basepath}/config.json" ]; then
-    echo "Unable to find config.json in provided directory"
-		exit 1
-fi
+# if [ ! -f "${basepath}/config.json" ]; then
+#     echo "Unable to find config.json in provided directory"
+# 		exit 1
+# fi
 
 # create these directories if they don't already exist
 mkdir -p "${basepath}/logs"
@@ -23,7 +25,7 @@ mkdir -p "${basepath}/other_gradeables"
 mkdir -p "${basepath}/users"
 
 # run all of the modules and exit if an error occurs
-/usr/local/submitty/Lichen/bin/concatenate_all.py  $basepath $datapath || exit 1
-#/usr/local/submitty/Lichen/bin/tokenize_all.py     $basepath || exit 1
-#/usr/local/submitty/Lichen/bin/hash_all.py         $basepath || exit 1
-#/usr/local/submitty/Lichen/bin/compare_hashes.out  $basepath || exit 1
+./concatenate_all.py  "${basepath}" "${datapath}" || exit 1
+./tokenize_all.py     $basepath || exit 1
+#hash_all.py         $basepath || exit 1
+#compare_hashes.out  $basepath || exit 1

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -1,47 +1,25 @@
-#!/bin/bash
+# This script is the startup script for Lichen.  It accepts a single path to a
+# directory containing a config file and creates the necessary output directories
+# as appropriate, relative to the provided path.  It is possible to run this script
+# from the command line but it is meant to be run via the Plagiarism Detection UI.
 
-semester=$1
-course=$2
-gradeable=$3
+# TODO: Assert permissions, as necessary
 
-prev_argument=""
-prior_term_gradeables=()
-ignore_submissions=()
-for argument in "$@"
-do
-	if [[ $argument == --* ]]
-	then
-		prev_argument=$argument
-	else
-	    case $prev_argument in
-		"--language")
-			language=$argument
-		  	;;
-		"--window")
-		  	window=$argument
-		  	;;
-		"--threshold")
-		  	threshold=$argument
-		  	;;
-		"--regrex")
-		  	regrex=$argument
-		  	;;
-		"--provided_code_path")
-		  	provided_code_path=$argument
-		  	;;
-		"--prior_term_gradeables")
-			prior_term_gradeables+=("$argument")
-		  	;;
-		"--ignore_submissions")
-			ignore_submissions+=("$argument")
-		  	;;
-		esac
-	fi
-done
+basepath=$1 # holds the path to a directory containing a config for this gradeable
 
-/usr/local/submitty/Lichen/bin/concatenate_all.py  $semester $course $gradeable
-/usr/local/submitty/Lichen/bin/tokenize_all.py     $semester $course $gradeable  --${language}
-/usr/local/submitty/Lichen/bin/hash_all.py         $semester $course $gradeable  --window $window  --${language}
+# kill the script if there is no config file
+if [! -f "${basepath}/config.json" ]; then
+    echo "Unable to find config.json in provided directory"
+		exit 1
+fi
 
-/usr/local/submitty/Lichen/bin/compare_hashes.out  $semester $course $gradeable  --window $window
+# provided_code should already exist if the user wishes to run with provided code
+mkdir -p "${basepath}/logs"
+mkdir -p "${basepath}/other_gradeables"
+mkdir -p "${basepath}/users"
 
+
+/usr/local/submitty/Lichen/bin/concatenate_all.py  $basepath
+#/usr/local/submitty/Lichen/bin/tokenize_all.py     $basepath
+#/usr/local/submitty/Lichen/bin/hash_all.py         $basepath
+#/usr/local/submitty/Lichen/bin/compare_hashes.out  $basepath

--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -73,6 +73,12 @@ def main():
             my_tokenized_file = os.path.join(my_dir, "tokens.json")
             tokenize(lichen_config_data, my_concatenated_file, my_tokenized_file)
 
+    # ===========================================================================
+    # tokenize the provided code
+    provided_code_concat = os.path.join(args.basepath, "provided_code", "submission.concatenated")
+    provided_code_tokenized = os.path.join(args.basepath, "provided_code", "tokens.json")
+    tokenize(lichen_config_data, provided_code_concat, provided_code_tokenized)
+
     # ==========================================================================
     end_time = time.time()
     print("done in " + "%.0f" % (end_time - start_time) + " seconds")

--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -6,6 +6,7 @@ Tokenizes the concatenated files.
 import argparse
 import os
 import json
+import time
 import sys
 
 
@@ -42,6 +43,7 @@ def tokenize(lichen_config_data, my_concatenated_file, my_tokenized_file):
 
 
 def main():
+    start_time = time.time()
     args = parse_args()
 
     sys.stdout.write("TOKENIZE ALL...")
@@ -71,7 +73,9 @@ def main():
             my_tokenized_file = os.path.join(my_dir, "tokens.json")
             tokenize(lichen_config_data, my_concatenated_file, my_tokenized_file)
 
-    print("done")
+    # ==========================================================================
+    end_time = time.time()
+    print("done in " + "%.0f" % (end_time - start_time) + " seconds")
 
 
 if __name__ == "__main__":

--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -53,6 +53,10 @@ def main():
     # ===========================================================================
     # walk the subdirectories
     users_dir = os.path.join(args.basepath, "users")
+    if not os.path.isdir(users_dir):
+        print("Error: Unable to find users directory")
+        exit(1)
+
     for user in sorted(os.listdir(users_dir)):
         user_dir = os.path.join(users_dir, user)
         if not os.path.isdir(user_dir):
@@ -62,8 +66,6 @@ def main():
             my_dir = os.path.join(user_dir, version)
             if not os.path.isdir(my_dir):
                 continue
-
-            print(my_dir)
 
             my_concatenated_file = os.path.join(my_dir, "submission.concatenated")
             my_tokenized_file = os.path.join(my_dir, "tokens.json")

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -518,7 +518,7 @@ int main(int argc, char* argv[]) {
 
   // ---------------------------------------------------------------------------
   // Create a general summary of rankings of users by percentage match
-  std::cout << "writing rakings files..." << std::endl;
+  std::cout << "writing rankings files..." << std::endl;
   time(&start);
 
   // create a single file of students ranked by highest percentage of code plagiarised

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -257,7 +257,7 @@ int main(int argc, char* argv[]) {
 
   time(&end);
   double diff = difftime(end, start);
-  std::cout << "finished loading in " << diff  << "s" << std::endl;
+  std::cout << "finished loading in " << diff  << " seconds" << std::endl;
 
   // ---------------------------------------------------------------------------
   // THIS IS THE MAIN PLAGIARISM DETECTION ALGORITHM
@@ -325,7 +325,7 @@ int main(int argc, char* argv[]) {
 
   time(&end);
   diff = difftime(end, start);
-  std::cout << "finished walking in " << diff << "s" << std::endl;
+  std::cout << "finished walking in " << diff << " seconds" << std::endl;
 
   // ---------------------------------------------------------------------------
   // Writing the output files and merging the results
@@ -514,7 +514,7 @@ int main(int argc, char* argv[]) {
 
   time(&end);
   diff = difftime(end, start);
-  std::cout << "done merging and writing matches files in " << diff << "s" << std::endl;
+  std::cout << "done merging and writing matches files in " << diff << " seconds" << std::endl;
 
   // ---------------------------------------------------------------------------
   // Create a general summary of rankings of users by percentage match
@@ -623,11 +623,11 @@ int main(int argc, char* argv[]) {
 
   time(&end);
   diff = difftime(end, start);
-  std::cout << "finished writing rankings in " << diff << "s" << std::endl;
+  std::cout << "finished writing rankings in " << diff << " seconds" << std::endl;
 
   // ---------------------------------------------------------------------------
   time(&overall_end);
   double overall_diff = difftime(overall_end, overall_start);
-  std::cout << "done in " << overall_diff << "s" << std::endl;
+  std::cout << "done in " << overall_diff << " seconds" << std::endl;
 
 }

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -628,6 +628,6 @@ int main(int argc, char* argv[]) {
   // ---------------------------------------------------------------------------
   time(&overall_end);
   double overall_diff = difftime(overall_end, overall_start);
-  std::cout << "DONE in " << overall_diff << "s" << std::endl;
+  std::cout << "done in " << overall_diff << "s" << std::endl;
 
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [x] Documentation has been updated/added if relevant: https://github.com/Submitty/submitty.github.io/pull/354

### What is the current behavior?
After some discussion, it was decided to modify the file structure for Lichen results and refactor some of the code to be able to better implement features such as: 
- Configuring multiple runs for a single gradeable
- Including previous term gradeables in the Lichen matching algorithm (future feature)
- Ability to implement unit testing on files
- Add timestamps to the output log files

### What is the new behavior?
This PR is the complement of https://github.com/Submitty/Submitty/pull/6702. Between the two of them, support for the new file structure has been implemented fully. In addition, significant refactors were completed to reduce the dependence upon hardcoded paths and to introduce more rigorous error checking.

### Other information?
Below is the new directory structure for Lichen results:
```
lichen/
	nightly_rerun.json
	<gradeable>/
		<unique number>/
			config.json
			logs/
				lichen_job_output.txt
			provided_code/
				files/
					<files uploaded by instructor>
				
				submission.concatenated
				tokens.json
				hashes.txt
			other_gradeables/
				<term>__<course>__<gradeable>/
					<user>/
						<version>/
							submission.concatenated
							tokens.json
							hashes.txt
			users/
				<user>/
					<version>/
						submission.concatenated
						tokens.json
						hashes.txt
						matches.json
						ranking.txt
			overall_ranking.txt
```
