### PR TITLE
[Refactor:Plagiarism] Move error checks to concatenate_all.py

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -62,7 +62,7 @@ def validate(config, args):
     with open(langs_data_json_path, 'r') as langs_data_file:
         langs_data = json.load(langs_data_file)
         if language not in langs_data:
-            raise SystemExit(f"\n\nERROR! tokenizing and hashing not supported for language {language}\n\n")
+            raise SystemExit(f"ERROR! tokenizing not supported for language {language}")
 
     # Check values of common code threshold and sequence length
     if (threshold < 2):
@@ -79,7 +79,7 @@ def validate(config, args):
     for ptg in prior_term_gradeables:
         for field in ptg:
             if ".." in field:
-                raise SystemExit('ERROR! Invalid path component ".." in prior_term_gradeable field')
+                raise SystemExit('ERROR! Invalid component ".." in prior_term_gradeable path')
 
     # check permissions to make sure we have access to the prior term gradeables
     my_course_group_perms = Path(args.basepath).group()

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -7,7 +7,6 @@ the concatenated files.
 import argparse
 import os
 import json
-import sys
 import time
 import fnmatch
 from pathlib import Path
@@ -63,57 +62,48 @@ def validate(config, args):
     with open(langs_data_json_path, 'r') as langs_data_file:
         langs_data = json.load(langs_data_file)
         if language not in langs_data:
-            print(f"\n\nERROR! tokenizing and hashing not supported for language {language}\n\n")
-            exit(1)
+            raise SystemExit(f"\n\nERROR! tokenizing and hashing not supported for language {language}\n\n")
 
     # Check values of common code threshold and sequence length
     if (threshold < 2):
-        print("ERROR! threshold must be >= 2")
-        exit(1)
+        raise SystemExit("ERROR! threshold must be >= 2")
 
     if (sequence_length < 1):
-        print("ERROR! sequence_length must be >= 1")
-        exit(1)
+        raise SystemExit("ERROR! sequence_length must be >= 1")
 
     # Check for backwards crawling
     for e in regex_patterns:
         if ".." in e:
-            print('ERROR! Invalid path component ".." in regex')
-            exit(1)
+            raise SystemExit('ERROR! Invalid path component ".." in regex')
 
     for ptg in prior_term_gradeables:
         for field in ptg:
             if ".." in field:
-                print('ERROR! Invalid path component ".." in prior_term_gradeable field')
-                exit(1)
+                raise SystemExit('ERROR! Invalid path component ".." in prior_term_gradeable field')
 
     # check permissions to make sure we have access to the prior term gradeables
     my_course_group_perms = Path(args.basepath).group()
     for ptg in prior_term_gradeables:
         if Path(args.datapath, ptg["prior_semester"], ptg["prior_course"]).group()\
            != my_course_group_perms:
-            print(f"ERROR! Invalid permissions to access course {ptg['prior_semester']}"
+            raise SystemExit(f"ERROR! Invalid permissions to access course {ptg['prior_semester']}"
                   f"/{ptg['prior_course']}")
-            exit(1)
 
     # make sure the regex directory is one of the acceptable directories
     for dir in regex_dirs:
         if dir not in ["submissions", "results", "checkout"]:
-            print("ERROR! ", dir, " is not a valid input directory for Lichen")
-            exit(1)
+            raise SystemExit("ERROR! ", dir, " is not a valid input directory for Lichen")
 
 
 def main():
     start_time = time.time()
     args = parse_args()
 
-    sys.stdout.write("CONCATENATE ALL...")  # don't want a newline here so can't use print
-    sys.stdout.flush()
+    print("CONCATENATE ALL...", end="")
 
     config_path = os.path.join(args.basepath, "config.json")
     if not os.path.isfile(config_path):
-        print(f"ERROR! invalid config path provided ({config_path})")
-        exit(1)
+        raise SystemExit(f"ERROR! invalid config path provided ({config_path})")
 
     with open(config_path) as config_file:
         config = json.load(config_file)

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -26,13 +26,6 @@ def hasher(lichen_config_data, my_tokenized_file, my_hashes_file):
     data_json_path = "./data.json"  # data.json is in the Lichen/bin directory after install
     with open(data_json_path) as token_data_file:
         token_data = json.load(token_data_file)
-        if language not in token_data:
-            print("\n\nERROR: UNKNOWN HASHER\n\n")
-            exit(1)
-
-    if (sequence_length < 1):
-        print("ERROR! sequence_length must be >= 1")
-        exit(1)
 
     with open(my_tokenized_file, 'r', encoding='ISO-8859-1') as my_tf:
         with open(my_hashes_file, 'w') as my_hf:

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -9,7 +9,6 @@ import argparse
 import os
 import json
 import time
-import sys
 import hashlib
 
 
@@ -50,15 +49,13 @@ def main():
     with open(os.path.join(args.basepath, "config.json")) as lichen_config:
         lichen_config_data = json.load(lichen_config)
 
-    sys.stdout.write("HASH ALL...")
-    sys.stdout.flush()
+    print("HASH ALL...", end="")
 
     # ==========================================================================
     # walk the subdirectories of this gradeable
     users_dir = os.path.join(args.basepath, "users")
     if not os.path.isdir(users_dir):
-        print("Error: Unable to find users directory")
-        exit(1)
+        raise SystemExit("ERROR! Unable to find users directory")
 
     for user in sorted(os.listdir(users_dir)):
         user_dir = os.path.join(users_dir, user)
@@ -79,8 +76,7 @@ def main():
 
     other_gradeables_dir = os.path.join(args.basepath, "other_gradeables")
     if not os.path.isdir(other_gradeables_dir):
-        print("Error: Unable to find other gradeables directory")
-        exit(1)
+        raise SystemExit("ERROR! Unable to find other gradeables directory")
 
     for other_gradeable in sorted(os.listdir(other_gradeables_dir)):
         other_gradeable_dir = os.path.join(other_gradeables_dir, other_gradeable)

--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -7,7 +7,6 @@ import argparse
 import os
 import json
 import time
-import sys
 
 
 def parse_args():
@@ -42,8 +41,7 @@ def main():
     start_time = time.time()
     args = parse_args()
 
-    sys.stdout.write("TOKENIZE ALL...")
-    sys.stdout.flush()
+    print("TOKENIZE ALL...", end="")
 
     with open(os.path.join(args.basepath, "config.json")) as lichen_config:
         lichen_config_data = json.load(lichen_config)
@@ -52,8 +50,7 @@ def main():
     # walk the subdirectories to tokenize this gradeable's submissions
     users_dir = os.path.join(args.basepath, "users")
     if not os.path.isdir(users_dir):
-        print("Error: Unable to find users directory")
-        exit(1)
+        raise SystemExit("ERROR! Unable to find users directory")
 
     for user in sorted(os.listdir(users_dir)):
         user_dir = os.path.join(users_dir, user)
@@ -73,8 +70,7 @@ def main():
     # tokenize the other prior term gradeables' submissions
     other_gradeables_dir = os.path.join(args.basepath, "other_gradeables")
     if not os.path.isdir(other_gradeables_dir):
-        print("Error: Unable to find other gradeables directory")
-        exit(1)
+        raise SystemExit("ERROR! Unable to find other gradeables directory")
 
     for other_gradeable in sorted(os.listdir(other_gradeables_dir)):
         other_gradeable_dir = os.path.join(other_gradeables_dir, other_gradeable)

--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -24,11 +24,7 @@ def tokenize(lichen_config_data, my_concatenated_file, my_tokenized_file):
     data_json_path = "./data.json"  # data.json is in the Lichen/bin directory after install
     with open(data_json_path, 'r') as token_data_file:
         token_data = json.load(token_data_file)
-        if language not in token_data:
-            print("\n\nERROR: UNKNOWN TOKENIZER\n\n")
-            exit(1)
-        else:
-            language_token_data = token_data[language]
+        language_token_data = token_data[language]
 
     tokenizer = f"./{language_token_data['tokenizer']}"
 

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -192,9 +192,6 @@ int main(int argc, char* argv[]) {
   int sequence_length = config_file_json.value("sequence_length",1);
   int threshold = config_file_json.value("threshold",5);
 
-  assert (sequence_length >= 1);
-  assert (threshold >= 2);
-
   // error checking, confirm there are hashes to work with
   boost::filesystem::path users_root_directory = lichen_gradeable_path / "users";
   if (!boost::filesystem::exists(users_root_directory) ||


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
Error checking is currently done in many different places throughout Lichen and is typically only done on parameters just before they are used. This means that it is possible to fail a basic assertion after completing an expensive operation.

### What is the new behavior?
The relevant error checks that are not affected by the progress of the Lichen processes and can be done ahead of time are done immediately in `concatenate_all.py` instead of waiting until just before each parameter is used.

This change is also relevant for a future refactor discussed with @bmcutler involving sending zipped Lichen config directories to worker machines.

### Other information?
No breaking changes. Everything should still work as before.
