### PR TITLE
[Feature:Developer] Add dependabot to Lichen repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: pip
-    directory: "/requirements.txt"
+    directory: "/"
     schedule:
       interval: daily
       time: "10:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/requirements.txt"
+    schedule:
+      interval: daily
+      time: "10:00"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "[Dependency] "


### PR DESCRIPTION
### What is the current behavior?
PR https://github.com/Submitty/Lichen/pull/44 added a proper requirements.txt file containing a list of python dependencies for Lichen.  To ensure that these dependencies are kept up-to-date, it would be best to use [dependabot](https://github.com/dependabot/dependabot-core) to make pull requests when updates are available.

### What is the new behavior?
This PR adds a `dependabot.yml` file to the Lichen repository.