### PR TITLE
[Feature:Developer] Pin version of nlohmann/json dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 tools/assignments/*
 tests/__pycache__
+vendor/

--- a/install_lichen.sh
+++ b/install_lichen.sh
@@ -13,8 +13,6 @@ echo -e "Installing lichen... "
 lichen_repository_dir=/usr/local/submitty/GIT_CHECKOUT/Lichen
 lichen_installation_dir=/usr/local/submitty/Lichen
 
-nlohmann_dir=${lichen_repository_dir}/../vendor/nlohmann/json
-
 
 ########################################################################################################################
 # install dependencies
@@ -31,12 +29,18 @@ pip install -r ${lichen_repository_dir}/requirements.txt
 ########################################################################################################################
 # get tools/source code from other repositories
 
-if [ ! -e "${nlohmann_dir}" ]; then
-    echo "Check out the vendor nlohmann/json repository"
-    mkdir -p nlohmann_dir
-    git clone --depth 1 https://github.com/nlohmann/json.git ${nlohmann_dir}
-fi
+mkdir -p vendor/nlohmann
 
+NLOHMANN_JSON_VERSION=3.9.1
+
+echo "Checking for nlohmann/json: ${NLOHMANN_JSON_VERSION}"
+
+if [ -f vendor/nlohmann/json.hpp ] && head -n 10 vendor/nlohmann/json.hpp | grep -q "version ${NLOHMANN_JSON_VERSION}"; then
+    echo "  already installed"
+else
+    echo "  downloading"
+    wget -O vendor/nlohmann/json.hpp https://github.com/nlohmann/json/releases/download/v${NLOHMANN_JSON_VERSION}/json.hpp > /dev/null
+fi
 
 ########################################################################################################################
 # compile & install the tools
@@ -47,7 +51,7 @@ mkdir -p ${lichen_installation_dir}/tools/assignments
 #--------------------
 # plaintext tool
 pushd ${lichen_repository_dir}  > /dev/null
-clang++ -I ${nlohmann_dir}/include/ -std=c++11 -Wall tokenizer/plaintext/plaintext_tokenizer.cpp -o ${lichen_installation_dir}/bin/plaintext_tokenizer.out
+clang++ -I vendor/ -std=c++11 -Wall tokenizer/plaintext/plaintext_tokenizer.cpp -o ${lichen_installation_dir}/bin/plaintext_tokenizer.out
 if [ $? -ne 0 ]; then
     echo -e "ERROR: FAILED TO BUILD PLAINTEXT TOKENIZER\n"
     exit 1
@@ -58,7 +62,7 @@ popd > /dev/null
 #-------------------------------------------
 # compile & install the hash comparison tool
 pushd ${lichen_repository_dir}  > /dev/null
-clang++ -I ${nlohmann_dir}/include/ -lboost_system -lboost_filesystem -Wall -g -std=c++11 -Wall compare_hashes/compare_hashes.cpp -o ${lichen_installation_dir}/bin/compare_hashes.out
+clang++ -I vendor/ -lboost_system -lboost_filesystem -Wall -g -std=c++11 -Wall compare_hashes/compare_hashes.cpp -o ${lichen_installation_dir}/bin/compare_hashes.out
 if [ $? -ne 0 ]; then
     echo -e "ERROR: FAILED TO BUILD HASH COMPARISON TOOL\n"
     exit 1


### PR DESCRIPTION
### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->

When installing Lichen, it checks if `/usr/local/submitty/vendor/nlohmann/json` exists, and if not, it will clone the [nlohmann/json](https://github.com/nlohmann/json) library and uses that as part of the cpp compile process. As part of the cloning, we use the default `develop` branch in the repo. The thought here being that Lichen can share the same version of nlohmann/json as the principal Submitty system.

### What is the new behavior?

This changes it so that Lichen will maintain its own nlohmann dependency, that is also versioned to only use dedicated releases. This accomplishes the following:
1. We don't risk Lichen randomly breaking as nlohmann/json is developed
2. Lichen (as a dedicated repo) can rely on its own version of nlohmann and not break if Submitty updates its dependency.
3. We save on not cloning an entire repo to get just one file

While this does mean that Lichen's version of nlohmann could drift from Submitty's version, I would consider that fine given the repo separation of the two. A con here is that on new versions of nlohmann, may have to update the version across multiple repos, but could create a simple GH action similar to dependabot to help keep up-to-date these versions that are defined as environment variables.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
