### PR TITLE
[Refactor:Plagiarism] Improve Lichen memory efficiency

### DIFF
--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -22,9 +22,9 @@
 // helper typedefs
 
 typedef int location_in_submission;
-typedef std::string hash;
+typedef unsigned int hash;
 typedef std::string user_id;
-typedef int version_number;
+typedef unsigned int version_number;
 
 
 // =============================================================================
@@ -113,11 +113,11 @@ int main(int argc, char* argv[]) {
   assert (istr.good());
   nlohmann::json config_file_json = nlohmann::json::parse(istr);
 
-  std::string semester = config_file_json.value("semester","ERROR");
-  std::string course = config_file_json.value("course","ERROR");
-  std::string gradeable = config_file_json.value("gradeable","ERROR");
-  int sequence_length = config_file_json.value("sequence_length",1);
-  int threshold = config_file_json.value("threshold",5);
+  std::string semester = config_file_json.value("semester", "ERROR");
+  std::string course = config_file_json.value("course", "ERROR");
+  std::string gradeable = config_file_json.value("gradeable", "ERROR");
+  int sequence_length = config_file_json.value("sequence_length", 1);
+  int threshold = config_file_json.value("threshold", 5);
 
   // error checking, confirm there are hashes to work with
   boost::filesystem::path users_root_directory = lichen_gradeable_path / "users";
@@ -188,9 +188,10 @@ int main(int argc, char* argv[]) {
         boost::filesystem::path other_hash_file = other_version_path / "hashes.txt";
         std::ifstream istr(other_hash_file.string());
         assert(istr.good());
-        hash input_hash;
+        std::string input_hash_str;
         int location = 0;
-        while (istr >> input_hash) {
+        while (istr >> input_hash_str) {
+          hash input_hash = (unsigned int)(stoul(input_hash_str, 0, 16));
           location++;
           other_gradeables[input_hash][other_username].push_back(HashLocation(other_username, other_version, location, other_gradeable_str));
         }
@@ -221,9 +222,10 @@ int main(int argc, char* argv[]) {
       hash_file /= "hashes.txt";
       std::ifstream istr(hash_file.string());
       assert(istr.good());
-      hash input_hash;
+      std::string input_hash_str;
       int location = 0;
-      while (istr >> input_hash) {
+      while (istr >> input_hash_str) {
+        hash input_hash = (unsigned int)(stoul(input_hash_str, 0, 16));
         location++;
         all_hashes[input_hash][username].push_back(HashLocation(username, version, location, semester+"__"+course+"__"+gradeable));
         curr_submission->addHash(input_hash, location);
@@ -509,12 +511,12 @@ int main(int argc, char* argv[]) {
     std::vector<StudentRanking> student_ranking;
     std::unordered_map<std::string, std::unordered_map<user_id, std::unordered_map<version_number, std::unordered_set<hash>>>> matches = (*submission_itr)->getStudentsMatched();
 
-    std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<int, std::unordered_set<hash>>>>::const_iterator gradeables_itr = matches.begin();
+    std::unordered_map<std::string, std::unordered_map<user_id, std::unordered_map<version_number, std::unordered_set<hash>>>>::const_iterator gradeables_itr = matches.begin();
     for (; gradeables_itr != matches.end(); ++gradeables_itr) {
       for (std::unordered_map<user_id, std::unordered_map<version_number, std::unordered_set<hash>>>::const_iterator matches_itr = gradeables_itr->second.begin();
          matches_itr != gradeables_itr->second.end(); ++matches_itr) {
 
-        for (std::unordered_map<int, std::unordered_set<hash>>::const_iterator version_itr = matches_itr->second.begin();
+        for (std::unordered_map<version_number, std::unordered_set<hash>>::const_iterator version_itr = matches_itr->second.begin();
              version_itr != matches_itr->second.end(); ++version_itr) {
 
           // Calculate the Percent Match:

--- a/compare_hashes/hash_location.h
+++ b/compare_hashes/hash_location.h
@@ -1,0 +1,26 @@
+#ifndef HASH_LOCATION_H
+#define HASH_LOCATION_H
+
+#include <string>
+#include <unordered_map>
+
+typedef int location_in_submission;
+typedef std::string hash;
+
+// represents the location of a hash within
+// a unique student and version pair
+struct HashLocation {
+  HashLocation(const std::string &s, int v, location_in_submission l, const std::string &sg) : student(s), version(v), location(l), source_gradeable(sg) {}
+  std::string student;
+  int version;
+  location_in_submission location;
+  std::string source_gradeable;
+};
+
+bool operator < (const HashLocation &hl1, const HashLocation &hl2) {
+  return hl1.student > hl2.student ||
+         (hl1.student == hl2.student && hl1.version < hl2.version) ||
+         (hl1.student == hl2.student && hl1.version == hl2.version && hl1.location < hl2.location);
+}
+
+#endif

--- a/compare_hashes/hash_location.h
+++ b/compare_hashes/hash_location.h
@@ -5,9 +5,9 @@
 #include <unordered_map>
 
 typedef int location_in_submission;
-typedef std::string hash;
+typedef unsigned int hash;
 typedef std::string user_id;
-typedef int version_number;
+typedef unsigned int version_number;
 
 // represents the location of a hash within
 // a unique student and version pair

--- a/compare_hashes/hash_location.h
+++ b/compare_hashes/hash_location.h
@@ -6,13 +6,15 @@
 
 typedef int location_in_submission;
 typedef std::string hash;
+typedef std::string user_id;
+typedef int version_number;
 
 // represents the location of a hash within
 // a unique student and version pair
 struct HashLocation {
-  HashLocation(const std::string &s, int v, location_in_submission l, const std::string &sg) : student(s), version(v), location(l), source_gradeable(sg) {}
+  HashLocation(const user_id &s, version_number v, location_in_submission l, const std::string &sg) : student(s), version(v), location(l), source_gradeable(sg) {}
   std::string student;
-  int version;
+  version_number version;
   location_in_submission location;
   std::string source_gradeable;
 };

--- a/compare_hashes/submission.h
+++ b/compare_hashes/submission.h
@@ -1,0 +1,67 @@
+#ifndef SUBMISSION_H
+#define SUBMISSION_H
+
+#include <string>
+#include <unordered_map>
+#include <map>
+#include <unordered_set>
+#include <set>
+#include <vector>
+
+#include "hash_location.h"
+
+typedef int location_in_submission;
+typedef std::string hash;
+
+// represents a unique student-version pair, all its
+// hashes, and other submissions with those hashes
+class Submission {
+public:
+  // CONSTRUCTOR
+  Submission(const std::string &s, int v) : student_(s), version_(v) {}
+
+  // GETTERS
+  const std::string & student() const { return student_; }
+  int version() const { return version_; }
+
+  const std::map<location_in_submission, std::set<HashLocation> >& getSuspiciousMatches() const {
+    return suspicious_matches;
+  }
+  const std::set<location_in_submission>& getCommonMatches() const { return common_matches; }
+  const std::set<location_in_submission>& getProvidedMatches() const { return provided_matches; }
+  const std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<int, std::unordered_set<hash>>>>& getStudentsMatched() const {
+    return students_matched;
+  }
+  float getPercentage() const {
+    return (100.0 * (suspicious_matches.size())) / hashes.size();
+  }
+
+  // MODIFIERS
+  void addHash(const hash &h, location_in_submission l) { hashes.push_back(make_pair(h, l)); }
+  const std::vector<std::pair<hash, location_in_submission>> & getHashes() const { return hashes; }
+
+  void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location, hash matched_hash) {
+    // save the found match
+    suspicious_matches[location].insert(matching_location);
+    // update the students_matched container
+    students_matched[matching_location.source_gradeable][matching_location.student][matching_location.version].insert(matched_hash);
+  }
+
+  void addCommonMatch(location_in_submission location) { common_matches.insert(location); }
+  void addProvidedMatch(location_in_submission location) { provided_matches.insert(location); }
+
+private:
+  std::string student_;
+  int version_;
+  std::vector<std::pair<hash, location_in_submission> > hashes;
+  std::map<location_in_submission, std::set<HashLocation> > suspicious_matches;
+  std::set<location_in_submission> common_matches;
+  std::set<location_in_submission> provided_matches;
+
+  // a container to keep track of all the students this submission
+  // matched and the number of matching hashes per submission
+  // <source_gradeable, <username, <version, <hashes>> > >
+  std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<int, std::unordered_set<hash>>>> students_matched;
+};
+
+#endif

--- a/compare_hashes/submission.h
+++ b/compare_hashes/submission.h
@@ -12,35 +12,33 @@
 
 typedef int location_in_submission;
 typedef std::string hash;
+typedef std::string user_id;
+typedef int version_number;
 
 // represents a unique student-version pair, all its
 // hashes, and other submissions with those hashes
 class Submission {
 public:
   // CONSTRUCTOR
-  Submission(const std::string &s, int v) : student_(s), version_(v) {}
+  Submission(const user_id &s, version_number v) : student_(s), version_(v) {}
 
   // GETTERS
-  const std::string & student() const { return student_; }
-  int version() const { return version_; }
+  const user_id& student() const { return student_; }
+  version_number version() const { return version_; }
 
-  const std::map<location_in_submission, std::set<HashLocation> >& getSuspiciousMatches() const {
-    return suspicious_matches;
-  }
+  const std::map<location_in_submission, std::set<HashLocation> >& getSuspiciousMatches() const { return suspicious_matches; }
   const std::set<location_in_submission>& getCommonMatches() const { return common_matches; }
   const std::set<location_in_submission>& getProvidedMatches() const { return provided_matches; }
-  const std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<int, std::unordered_set<hash>>>>& getStudentsMatched() const {
-    return students_matched;
-  }
+  const std::unordered_map<std::string, std::unordered_map<user_id, std::unordered_map<version_number, std::unordered_set<hash>>>>& getStudentsMatched() const { return students_matched; }
+  const std::vector<std::pair<hash, location_in_submission>> & getHashes() const { return hashes; }
   float getPercentage() const {
     return (100.0 * (suspicious_matches.size())) / hashes.size();
   }
 
   // MODIFIERS
   void addHash(const hash &h, location_in_submission l) { hashes.push_back(make_pair(h, l)); }
-  const std::vector<std::pair<hash, location_in_submission>> & getHashes() const { return hashes; }
 
-  void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location, hash matched_hash) {
+  void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location, const hash &matched_hash) {
     // save the found match
     suspicious_matches[location].insert(matching_location);
     // update the students_matched container
@@ -51,8 +49,8 @@ public:
   void addProvidedMatch(location_in_submission location) { provided_matches.insert(location); }
 
 private:
-  std::string student_;
-  int version_;
+  user_id student_;
+  version_number version_;
   std::vector<std::pair<hash, location_in_submission> > hashes;
   std::map<location_in_submission, std::set<HashLocation> > suspicious_matches;
   std::set<location_in_submission> common_matches;
@@ -61,7 +59,7 @@ private:
   // a container to keep track of all the students this submission
   // matched and the number of matching hashes per submission
   // <source_gradeable, <username, <version, <hashes>> > >
-  std::unordered_map<std::string, std::unordered_map<std::string, std::unordered_map<int, std::unordered_set<hash>>>> students_matched;
+  std::unordered_map<std::string, std::unordered_map<user_id, std::unordered_map<version_number, std::unordered_set<hash>>>> students_matched;
 };
 
 #endif

--- a/compare_hashes/submission.h
+++ b/compare_hashes/submission.h
@@ -11,9 +11,9 @@
 #include "hash_location.h"
 
 typedef int location_in_submission;
-typedef std::string hash;
+typedef unsigned int hash;
 typedef std::string user_id;
-typedef int version_number;
+typedef unsigned int version_number;
 
 // represents a unique student-version pair, all its
 // hashes, and other submissions with those hashes
@@ -36,7 +36,7 @@ public:
   }
 
   // MODIFIERS
-  void addHash(const hash &h, location_in_submission l) { hashes.push_back(make_pair(h, l)); }
+  void addHash(const hash &h, location_in_submission l) { hashes.push_back(std::make_pair(h, l)); }
 
   void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location, const hash &matched_hash) {
     // save the found match


### PR DESCRIPTION
### What is the current behavior?
Lichen currently uses an excessive amount of memory because it loads all of the hashes from each file, processes each submission, and then writes the `matches.json` files, storing the data for each submission throughout the entire run.

### What is the new behavior?
This PR simplifies two loops such that data is only stored in memory when it is actively being used.  In doing so, the memory used by `compare_hashes.cpp` is reduced by a factor of `s` for `s` submissions.  In testing, a reduction of two orders of magnitude in maximum memory used was noted, although this number will vary depending on the complexity of a given run.

In addition, the type used to store hashes was changed from a `std::string` to an `unsigned int`.  This change reduces the running time and memory usage slightly by making access to `std::unordered_map` structures containing hashes faster and more memory efficient.

### Other information?
Since this PR introduces manual memory management to `compare_hashes.cpp`, a future PR will be made to introduce a unit test which runs `compare_hashes.cpp` under Dr. Memory or Valgrind to protect against future changes introducing memory leaks.
