### PR TITLE
[Bugfix:Plagiarism] Clean up temp files on failure

### DIFF
--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -71,9 +71,9 @@ mkdir -p "${basepath}/users"
 
     ############################################################################
     # Run Lichen
-    ./tokenize_all.py    "$tmp_location" || { rm -rf $tmp_location; rm "/tmp/LICHEN_JOB_${archive_name}.tar.gz"; exit 1; }
-    ./hash_all.py        "$tmp_location" || { rm -rf $tmp_location; rm "/tmp/LICHEN_JOB_${archive_name}.tar.gz"; exit 1; }
-    ./compare_hashes.out "$tmp_location" || { rm -rf $tmp_location; rm "/tmp/LICHEN_JOB_${archive_name}.tar.gz"; exit 1; }
+    ./tokenize_all.py    "$tmp_location" || { rm -rf $tmp_location; exit 1; }
+    ./hash_all.py        "$tmp_location" || { rm -rf $tmp_location; exit 1; }
+    ./compare_hashes.out "$tmp_location" || { rm -rf $tmp_location; exit 1; }
 
     ############################################################################
     # Zip the results back up and send them back to the course's lichen directory

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -71,9 +71,9 @@ mkdir -p "${basepath}/users"
 
     ############################################################################
     # Run Lichen
-    ./tokenize_all.py    "$tmp_location" || exit 1
-    ./hash_all.py        "$tmp_location" || exit 1
-    ./compare_hashes.out "$tmp_location" || exit 1
+    ./tokenize_all.py    "$tmp_location" || { rm -rf $tmp_location; rm "/tmp/LICHEN_JOB_${archive_name}.tar.gz"; exit 1; }
+    ./hash_all.py        "$tmp_location" || { rm -rf $tmp_location; rm "/tmp/LICHEN_JOB_${archive_name}.tar.gz"; exit 1; }
+    ./compare_hashes.out "$tmp_location" || { rm -rf $tmp_location; rm "/tmp/LICHEN_JOB_${archive_name}.tar.gz"; exit 1; }
 
     ############################################################################
     # Zip the results back up and send them back to the course's lichen directory


### PR DESCRIPTION
### What is the current behavior?
PR #45 changed the behavior of Lichen to do all processing beyond the concatenation stage outside the course's Lichen directory in a temporary directory.  When tokenization, hashing, or hash comparison fails, the temporary directories remain, leading to collisions the next time Lichen is run with that configuration, in addition to several large files being left in `/tmp`.

### What is the new behavior?
This bugfix PR fixes the issues with files not being cleaned up.