### PR TITLE
[Feature:Plagiarism] Add reasonable limits to file sizes

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -16,7 +16,9 @@ from pathlib import Path
 IGNORED_FILES = [
     ".submit.timestamp"
 ]
-MAX_CONCAT_SIZE = 1e9
+
+with open(Path(__file__).resolve().parent / "lichen_config.json") as lichen_config_file:
+    LICHEN_CONFIG = json.load(lichen_config_file)
 
 
 # returns a string containing the contents of the files which match the regex in the specified dir
@@ -45,8 +47,9 @@ def getConcatFilesInDir(input_dir, regex_patterns):
 
 
 def checkTotalSize(total_concat):
-    if total_concat > MAX_CONCAT_SIZE:
-        raise SystemExit(f"ERROR! exceeded {humanize.naturalsize(MAX_CONCAT_SIZE)}"
+    if total_concat > LICHEN_CONFIG['concat_max_total_bytes']:
+        raise SystemExit("ERROR! exceeded"
+                         f"{humanize.naturalsize(LICHEN_CONFIG['concat_max_total_bytes'])}"
                          " of concatenated files allowed")
 
 

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -41,7 +41,7 @@ def hasher(lichen_config, lichen_run_config, my_tokenized_file, my_hashes_file):
                     .hexdigest())[0:8] for x in range(0, num-sequence_length+1)]
 
                 if len(token_hashed_values) > lichen_config["max_sequences_per_file"]:
-                    token_hashed_values = token_hashed_values[slice(0, lichen_config["max_sequences_per_file"])] #noqa E501
+                    token_hashed_values = token_hashed_values[slice(0, lichen_config["max_sequences_per_file"])]  #noqa E501
                     print(f"File {my_hashes_file} truncated after exceeding max sequence limit")
 
                 my_hf.write('\n'.join(token_hashed_values))

--- a/bin/hash_all.py
+++ b/bin/hash_all.py
@@ -41,7 +41,7 @@ def hasher(lichen_config, lichen_run_config, my_tokenized_file, my_hashes_file):
                     .hexdigest())[0:8] for x in range(0, num-sequence_length+1)]
 
                 if len(token_hashed_values) > lichen_config["max_sequences_per_file"]:
-                    token_hashed_values = token_hashed_values[slice(0, lichen_config["max_sequences_per_file"])]  #noqa E501
+                    token_hashed_values = token_hashed_values[slice(0, lichen_config["max_sequences_per_file"])]  # noqa E501
                     print(f"File {my_hashes_file} truncated after exceeding max sequence limit")
 
                 my_hf.write('\n'.join(token_hashed_values))

--- a/bin/lichen_config.json
+++ b/bin/lichen_config.json
@@ -1,0 +1,5 @@
+{
+  "concat_max_total_bytes": 1000000000,
+  "max_sequences_per_file": 10000,
+  "max_matching_positions": 30
+}

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -7,14 +7,28 @@
 
 # TODO: Assert permissions, as necessary
 
-basepath=$1 # holds the path to a directory containing a config for this gradeable
+BASEPATH=$1 # holds the path to a directory containing a config for this gradeable
             # (probably .../lichen/gradeable/<unique number>/ on Submitty)
 
-datapath=$2 # holds the path to a directory conatining courses and their data
+DATAPATH=$2 # holds the path to a directory conatining courses and their data
             # (probably /var/local/submitty/courses on Submitty)
 
+KILL_ERROR_MESSAGE="
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+* An error occured while running Lichen. Your run was probably killed for using *
+* too much memory. Before rerunning, perhaps try any of the following edits to  *
+* the configuration:                                                            *
+* - Increasing the sequence length                                              *
+* - Using only active version                                                   *
+* - Decreasing the common code threshold                                        *
+* - Selecting fewer files to be compared                                        *
+* - Comparing against fewer other gradeables                                    *
+* - Uploading provided code files                                               *
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+"
+
 # kill the script if there is no config file
-if [ ! -f "${basepath}/config.json" ]; then
+if [ ! -f "${BASEPATH}/config.json" ]; then
     echo "Unable to find config.json in provided directory"
 		exit 1
 fi
@@ -22,20 +36,20 @@ fi
 
 # delete any previous run results
 # TODO: determine if any caching should occur
-rm -rf "${basepath}/logs"
-rm -rf "${basepath}/other_gradeables"
-rm -rf "${basepath}/users"
-rm -f "${basepath}/overall_ranking.txt"
-rm -f "${basepath}/provided_code/submission.concatenated"
-rm -f "${basepath}/provided_code/tokens.json"
-rm -f "${basepath}/provided_code/hashes.txt"
+rm -rf "${BASEPATH}/logs"
+rm -rf "${BASEPATH}/other_gradeables"
+rm -rf "${BASEPATH}/users"
+rm -f "${BASEPATH}/overall_ranking.txt"
+rm -f "${BASEPATH}/provided_code/submission.concatenated"
+rm -f "${BASEPATH}/provided_code/tokens.json"
+rm -f "${BASEPATH}/provided_code/hashes.txt"
 
 # create these directories if they don't already exist
-mkdir -p "${basepath}/logs"
-mkdir -p "${basepath}/provided_code"
-mkdir -p "${basepath}/provided_code/files"
-mkdir -p "${basepath}/other_gradeables"
-mkdir -p "${basepath}/users"
+mkdir -p "${BASEPATH}/logs"
+mkdir -p "${BASEPATH}/provided_code"
+mkdir -p "${BASEPATH}/provided_code/files"
+mkdir -p "${BASEPATH}/other_gradeables"
+mkdir -p "${BASEPATH}/users"
 
 # Run Lichen and exit if an error occurs
 {
@@ -43,21 +57,21 @@ mkdir -p "${basepath}/users"
     # Finish setting up Lichen run
 
     # The default is r-x and we need PHP to be able to write if edits are made to the provided code
-    chmod g=rwxs "${basepath}/provided_code/files" || exit 1
+    chmod g=rwxs "${BASEPATH}/provided_code/files" || exit 1
 
     cd "$(dirname "${0}")" || exit 1
 
     ############################################################################
     # Do some preprocessing
     echo "Beginning Lichen run: $(date +"%Y-%m-%d %H:%M:%S")"
-    ./concatenate_all.py "$basepath" "$datapath" || exit 1
+    ./concatenate_all.py "$BASEPATH" "$DATAPATH" || exit 1
 
     ############################################################################
     # Move the file somewhere to be processed (eventually this will be a worker machine)
 
     # Tar+zip the file structure and save it to /tmp
-    cd $basepath || exit 1
-    archive_name=$(sha1sum "${basepath}/config.json" | awk '{ print $1 }') || exit 1
+    cd $BASEPATH || exit 1
+    archive_name=$(sha1sum "${BASEPATH}/config.json" | awk '{ print $1 }') || exit 1
     tar -czf "/tmp/LICHEN_JOB_${archive_name}.tar.gz" "config.json" "other_gradeables" "users" "provided_code" || exit 1
     cd "$(dirname "${0}")" || exit 1
 
@@ -73,7 +87,7 @@ mkdir -p "${basepath}/users"
     # Run Lichen
     ./tokenize_all.py    "$tmp_location" || exit 1
     ./hash_all.py        "$tmp_location" || exit 1
-    ./compare_hashes.out "$tmp_location" || exit 1
+    ./compare_hashes.out "$tmp_location" || {echo $KILL_ERROR_MESSAGE; exit 1}
 
     ############################################################################
     # Zip the results back up and send them back to the course's lichen directory
@@ -84,8 +98,8 @@ mkdir -p "${basepath}/users"
     # TODO: Move the archive back from worker machine
 
     # Extract archive and restore Lichen file structure
-    cd $basepath || exit 1
-    tar --skip-old-files -xzf "/tmp/LICHEN_JOB_${archive_name}.tar.gz" -C "$basepath"
+    cd $BASEPATH || exit 1
+    tar --skip-old-files -xzf "/tmp/LICHEN_JOB_${archive_name}.tar.gz" -C "$BASEPATH"
     rm "/tmp/LICHEN_JOB_${archive_name}.tar.gz" || exit 1
 
-} >> "${basepath}/logs/lichen_job_output.txt" 2>&1
+} >> "${BASEPATH}/logs/lichen_job_output.txt" 2>&1

--- a/bin/process_all.sh
+++ b/bin/process_all.sh
@@ -15,9 +15,9 @@ DATAPATH=$2 # holds the path to a directory conatining courses and their data
 
 KILL_ERROR_MESSAGE="
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-* An error occured while running Lichen. Your run was probably killed for using *
-* too much memory. Before rerunning, perhaps try any of the following edits to  *
-* the configuration:                                                            *
+* An error occured while running Lichen. Your run was probably killed for       *
+* exceeding the configured resource limits. Before rerunning, perhaps try any   *
+* of the following edits to the configuration:                                  *
 * - Increasing the sequence length                                              *
 * - Using only active version                                                   *
 * - Decreasing the common code threshold                                        *
@@ -25,7 +25,7 @@ KILL_ERROR_MESSAGE="
 * - Comparing against fewer other gradeables                                    *
 * - Uploading provided code files                                               *
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-"
+";
 
 # kill the script if there is no config file
 if [ ! -f "${BASEPATH}/config.json" ]; then
@@ -85,20 +85,20 @@ mkdir -p "${BASEPATH}/users"
 
     ############################################################################
     # Run Lichen
-    ./tokenize_all.py    "$tmp_location" || { rm -rf $tmp_location; exit 1; }
-    ./hash_all.py        "$tmp_location" || { rm -rf $tmp_location; exit 1; }
-    ./compare_hashes.out "$tmp_location" || { rm -rf $tmp_location; exit 1; }
+    ./tokenize_all.py    "$tmp_location" || { rm -rf "$tmp_location"; exit 1; }
+    ./hash_all.py        "$tmp_location" || { rm -rf "$tmp_location"; exit 1; }
+    ./compare_hashes.out "$tmp_location" || { rm -rf "$tmp_location"; echo "${KILL_ERROR_MESSAGE}"; exit 1; }
 
     ############################################################################
     # Zip the results back up and send them back to the course's lichen directory
     cd $tmp_location || exit 1
     tar -czf "/tmp/LICHEN_JOB_${archive_name}.tar.gz" "."
-    rm -rf $tmp_location || exit 1
+    rm -rf "$tmp_location" || exit 1
 
     # TODO: Move the archive back from worker machine
 
     # Extract archive and restore Lichen file structure
-    cd $BASEPATH || exit 1
+    cd "$BASEPATH" || exit 1
     tar --skip-old-files -xzf "/tmp/LICHEN_JOB_${archive_name}.tar.gz" -C "$BASEPATH"
     rm "/tmp/LICHEN_JOB_${archive_name}.tar.gz" || exit 1
 

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -161,6 +161,7 @@ bool ranking_sorter(const StudentRanking &a, const StudentRanking &b) {
 // ===================================================================================
 int main(int argc, char* argv[]) {
   std::cout << "COMPARE HASHES...";
+  return 1;
   fflush(stdout);
   time_t overall_start, overall_end;
   time(&overall_start);

--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -97,21 +97,26 @@ bool ranking_sorter(const StudentRanking &a, const StudentRanking &b) {
 
 int main(int argc, char* argv[]) {
   std::cout << "COMPARE HASHES...";
-  return 1;
   fflush(stdout);
   time_t overall_start, overall_end;
   time(&overall_start);
 
   // ===========================================================================
+  // load Lichen config data
+  std::ifstream lichen_config_istr("./lichen_config.json");
+  assert(lichen_config_istr.good());
+  nlohmann::json lichen_config = nlohmann::json::parse(lichen_config_istr);
+
+  // ===========================================================================
   // load config info
 
-  assert (argc == 2);
+  assert(argc == 2);
   std::string lichen_gradeable_path_str = argv[1];
   boost::filesystem::path lichen_gradeable_path = boost::filesystem::system_complete(lichen_gradeable_path_str);
   boost::filesystem::path config_file_json_path = lichen_gradeable_path / "config.json";
 
   std::ifstream istr(config_file_json_path.string());
-  assert (istr.good());
+  assert(istr.good());
   nlohmann::json config_file_json = nlohmann::json::parse(istr);
 
   std::string semester = config_file_json.value("semester", "ERROR");
@@ -321,7 +326,7 @@ int main(int argc, char* argv[]) {
       continue;
     }
 
-    // Save this submissions highest percent match for later when we geenrate overall_rankings.txt
+    // Save this submissions highest percent match for later when we generate overall_rankings.txt
     float percentMatch = (*submission_itr)->getPercentage();
 
     std::unordered_map<std::string, std::pair<int, float> >::iterator highest_matches_itr = highest_matches.find((*submission_itr)->student());
@@ -376,11 +381,18 @@ int main(int argc, char* argv[]) {
             // keep iterating and editing the same object until a we get to a different submission
             if (matching_positions_itr->student != other["username"]
                 || matching_positions_itr->version != other["version"]
-                || matching_positions_itr->source_gradeable != other["source_gradeable"]) {
+                || matching_positions_itr->source_gradeable != other["source_gradeable"]
+                || matchingpositions.size() >= lichen_config["max_matching_positions"]) {
 
               // found a different one, we push the old one and start over
               other["matchingpositions"] = matchingpositions;
               others.push_back(other);
+
+              if (matchingpositions.size() >= lichen_config["max_matching_positions"]) {
+                std::cout << "Matching positions array truncated for user: [" << other["username"] << "] version: " << other["version"] << std::endl;
+                std::cout << "  - Try increasing the sequence length to fix this problem." << std::endl;
+                break;
+              }
 
               matchingpositions.clear();
               other["username"] = matching_positions_itr->student;


### PR DESCRIPTION
### What is the current behavior?
It is currently possible to cause Lichen to use excessive amounts of memory, while running for extended periods of time, when improperly configured.

### What is the new behavior?
This PR adds reasonable limits to all potentially large aspects of a given Lichen run such that files which exceed the limits are truncated without failing altogether.  Future work will need to be done to add hard, fixed, limits on the amount of memory available and the time any given run is allowed to take.  For now, the collection of limits here should prevent any excessive memory usage by limiting all of the potentially large files to reasonable sizes.  All of the limits introduced have been condensed to a single `lichen_config.json` file containing:
- `concat_max_total_bytes`: the total number of bytes allowed to be concatenated in total
  - This is largely an attempt to prevent excessively large tar/zip archives from being moved around and an attempt to limit the duration of Lichen runs to a reasonable amount of time.
- `max_sequences_per_file`: the maximum number of hashes any given submission may contain
  - This is by far the most crucial and most restrictive limit which limits the size of a `matches.json` for any given submission to a reasonable upper bound.  Raising this limit too much may result in excessive memory usage while `compare_hashes.cpp` is attempting to build a large data structure.
- `max_matching_positions`: The maximum number of duplicate sequences there may be between any two submissions.
  - This serves as some amount of protection against the Lichen equivalent of a zip bomb, either accidental or deliberate.  Raising this limit too much may result in excessively large `matches.json` files, especially if two or more files contain significant amounts of repetition between them.  This also helps control the maximum memory usage used by Lichen.