### PR TITLE
[Feature:Plagiarism] Subtractive regex

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -29,12 +29,18 @@ def getConcatFilesInDir(input_dir, regex_patterns):
         files = sorted(my_files)
         if regex_patterns[0] != "":
             files_filtered = []
+            # resolve all of the additions
             for e in regex_patterns:
                 # Regex patterns starting with a ! indicate that files should be excluded
-                if e.strip().startswith("!"):
-                    files_filtered.extend([file for file in files if file not in fnmatch.filter(files, e.strip().replace("!", ""))])
-                else:
+                if not e.strip().startswith("!"):
                     files_filtered.extend(fnmatch.filter(files, e.strip()))
+
+            # resolve the subtractions
+            for e in regex_patterns:
+                if e.strip().startswith("!"):
+                    files_filtered = [file for file in files_filtered if file not in
+                                      fnmatch.filter(files_filtered, e.strip().replace("!", ""))]
+
             files = files_filtered
 
         for my_file in files:

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -30,7 +30,11 @@ def getConcatFilesInDir(input_dir, regex_patterns):
         if regex_patterns[0] != "":
             files_filtered = []
             for e in regex_patterns:
-                files_filtered.extend(fnmatch.filter(files, e.strip()))
+                # Regex patterns starting with a ! indicate that files should be excluded
+                if e.strip().startswith("!"):
+                    files_filtered.extend([file for file in files if file not in fnmatch.filter(files, e.strip().replace("!", ""))])
+                else:
+                    files_filtered.extend(fnmatch.filter(files, e.strip()))
             files = files_filtered
 
         for my_file in files:


### PR DESCRIPTION
### What is the current behavior?
Currently, it is only possible to use the regex field to select files to be added to the selection.  It is not possible to remove particular files from the selection.

### What is the new behavior?
This PR adds the `!` operator to the regex selection field to indicate files which should be removed from the selection.  The `!` operator does not add everything except the files selected by the following regex, but rather subtracts any files matched by the following regex from the files already selected by additive regex fields.

If you wish to select all files except for one, you must first select all files (`*`) and then remove the file you wish to exclude by prefixing a regex to select that file with the `!` operator.

Examples: (given files `submission_a.txt` and `submission_b.txt`)
- The regex: `*, !*a.txt` should select everything (`*`) and then remove any files which end with `a.txt` (`!*a.txt`) from that list, resulting in only `submission_b.txt` being selected.
- The regex: `!*a.txt` should add no files to the files to be matched, and then attempt to remove any files which match the pattern `*a.txt`.  Thus, no files will be selected in this case.  

A documentation PR which updates the instructor documentation for this field will be forthcoming.