### PR TITLE
[Refactor:Plagiarism] Change no files found warning

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -237,8 +237,6 @@ def main():
     # iterate over all of the created submissions, checking to see if they are empty
     # and printing a message if so
 
-    no_files_match_error = "ERROR! No files matched provided regex in selected directories"
-
     for user in os.listdir(os.path.join(args.basepath, "users")):
         user_path = os.path.join(args.basepath, "users", user)
         for version in os.listdir(user_path):

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -235,7 +235,7 @@ def main():
 
     # ==========================================================================
     # iterate over all of the created submissions, checking to see if they are empty
-    # and adding a message to the top if so (to differentiate empty files from errors in the UI)
+    # and printing a message if so
 
     no_files_match_error = "ERROR! No files matched provided regex in selected directories"
 
@@ -244,11 +244,10 @@ def main():
         for version in os.listdir(user_path):
             version_path = os.path.join(user_path, version)
             my_concatenated_file = os.path.join(version_path, "submission.concatenated")
-            with open(my_concatenated_file, "r+") as my_cf:
+            with open(my_concatenated_file, "r") as my_cf:
                 if my_cf.read() == "":
-                    my_cf.write(no_files_match_error)
-                    total_concat += sys.getsizeof(no_files_match_error)
-            checkTotalSize(total_concat)
+                    print("ERROR: No files matched provided regex in selected directories "
+                          f"for user {user} version {version}")
 
     # do the same for the other gradeables
     for other_gradeable in prior_term_gradeables:
@@ -260,11 +259,10 @@ def main():
             for other_version in os.listdir(other_user_path):
                 other_version_path = os.path.join(other_user_path, other_version)
                 my_concatenated_file = os.path.join(other_version_path, "submission.concatenated")
-                with open(my_concatenated_file, "r+") as my_cf:
+                with open(my_concatenated_file, "r") as my_cf:
                     if my_cf.read() == "":
-                        my_cf.write(no_files_match_error)
-                        total_concat += sys.getsizeof(no_files_match_error)
-                checkTotalSize(total_concat)
+                        print("ERROR: No files matched provided regex in selected directories "
+                              f"for user {other_user} version {other_version}")
 
     # ==========================================================================
     # concatenate provided code

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -244,7 +244,7 @@ def main():
             my_concatenated_file = os.path.join(version_path, "submission.concatenated")
             with open(my_concatenated_file, "r") as my_cf:
                 if my_cf.read() == "":
-                    print("ERROR: No files matched provided regex in selected directories "
+                    print("Warning: No files matched provided regex in selected directories "
                           f"for user {user} version {version}")
 
     # do the same for the other gradeables
@@ -259,7 +259,7 @@ def main():
                 my_concatenated_file = os.path.join(other_version_path, "submission.concatenated")
                 with open(my_concatenated_file, "r") as my_cf:
                     if my_cf.read() == "":
-                        print("ERROR: No files matched provided regex in selected directories "
+                        print("Warning: No files matched provided regex in selected directories "
                               f"for user {other_user} version {other_version}")
 
     # ==========================================================================


### PR DESCRIPTION
### What is the current behavior?
Lichen currently prints a warning message at the top of empty `submission.concatenated` files stating that no files were selected by the provided regex.  This is not ideal because it can mean that if a small number of students have the warning message, they get marked as having a 100% match with each other and thus, they move to the top of the rankings.

### What is the new behavior?
This PR adjusts the behavior of the empty files warning message to print a line in the log file instead of actually modifying the contents of the `submission.concatenated`.  