### PR TITLE
[Bugfix:System] Fix permissions on pip packages

### DIFF
--- a/install_lichen.sh
+++ b/install_lichen.sh
@@ -27,6 +27,15 @@ apt-get install -y libboost-all-dev
 # python requirements
 pip install -r ${lichen_repository_dir}/requirements.txt
 
+# These permissions changes are copied from Submitty/.setup/INSTALL_SUBMITTY_HELPER.sh
+# Setting the permissions are necessary as pip uses the umask of the user/system, which
+# affects the other permissions (which ideally should be o+rx, but Submitty sets it to o-rwx).
+# This gets run here in case we make any python package changes.
+find /usr/local/lib/python*/dist-packages -type d -exec chmod 755 {} +
+find /usr/local/lib/python*/dist-packages -type f -exec chmod 755 {} +
+find /usr/local/lib/python*/dist-packages -type f -name '*.py*' -exec chmod 644 {} +
+find /usr/local/lib/python*/dist-packages -type f -name '*.pth' -exec chmod 644 {} +
+
 ########################################################################################################################
 # get tools/source code from other repositories
 


### PR DESCRIPTION
### What is the current behavior?
Submitty has a global umask set which leads to permissions being set incorrectly when running `pip install`.  This can lead to package not found errors when running Lichen.  The `install_submitty` script has a block which changes the permissions of pip packages but no such block exists in `install_lichen.sh`.  When a package is added for the first time, it is currently necessary to run `install_submitty` twice to get the correct permissions.

### What is the new behavior?
This PR makes a simple change to modify the permissions of pip packages.  This block of code was copied from the similar `install_submitty` script found [here](https://github.com/Submitty/Submitty/blob/8339fc0222b8a860976faf2731b6ed0a98dbe4b0/.setup/INSTALL_SUBMITTY_HELPER.sh#L118).
