### PR TITLE
[Refactor:Plagiarism] Change format of regex field 

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -73,7 +73,7 @@ def parse_args():
 
 def validate(config, args):
     # load parameters from the config to be checked
-    regex_patterns = config["regex"].split(',')
+    regex_patterns = config["regex"]
     regex_dirs = config["regex_dirs"]
     language = config["language"]
     threshold = int(config["threshold"])
@@ -139,7 +139,7 @@ def main():
     course = config["course"]
     gradeable = config["gradeable"]
     version_mode = config["version"]
-    regex_patterns = config["regex"].split(',')
+    regex_patterns = config["regex"]
     regex_dirs = config["regex_dirs"]
     prior_term_gradeables = config["prior_term_gradeables"]
     users_to_ignore = config["ignore_submissions"]

--- a/tests/data/test_lichen/repeated_sequences/expected_output/config.json
+++ b/tests/data/test_lichen/repeated_sequences/expected_output/config.json
@@ -4,7 +4,7 @@
     "gradeable": "repeated_sequences",
     "config_id": "1",
     "version": "all_versions",
-    "regex": "",
+    "regex": [""],
     "regex_dirs": [
         "submissions"
     ],

--- a/tests/data/test_lichen/repeated_sequences/input/config.json
+++ b/tests/data/test_lichen/repeated_sequences/input/config.json
@@ -4,7 +4,7 @@
     "gradeable": "repeated_sequences",
     "config_id": "1",
     "version": "all_versions",
-    "regex": "",
+    "regex": [""],
     "regex_dirs": [
         "submissions"
     ],


### PR DESCRIPTION
### What is the current behavior?
The regex field in `config.json` is currently a string of comma-separated values which must be parsed by Lichen.

### What is the new behavior?
https://github.com/Submitty/Submitty/pull/6966 changes the behavior of the regex field such that PHP deals with splitting the regex field into an array before storing it in the database.  This PR includes a minor change to Lichen to use the same format.

### Other Information:
This PR includes a breaking change which depends upon https://github.com/Submitty/Submitty/pull/6966 to work with the UI properly.
