### PR TITLE
[Feature:Plagiarism] Get files only from `results/details`

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -217,6 +217,9 @@ def main():
                 # loop over each version
                 for other_version in sorted(os.listdir(other_user_path)):
                     other_version_path = os.path.join(other_user_path, other_version)
+                    if dir == "results":
+                        # only the "details" folder within "results" contains files relevant to Lichen
+                        other_version_path = os.path.join(other_version_path, "details")
                     if not os.path.isdir(other_version_path):
                         continue
 

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -168,6 +168,9 @@ def main():
             # loop over each version
             for version in sorted(os.listdir(user_path)):
                 version_path = os.path.join(user_path, version)
+                if dir == "results":
+                    # only the "details" folder within "results" contains files relevant to Lichen
+                    version_path = os.path.join(version_path, "details")
                 if not os.path.isdir(version_path):
                     continue
                 if version_mode == "active_version" and int(version) != my_active_version:

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -218,7 +218,7 @@ def main():
                 for other_version in sorted(os.listdir(other_user_path)):
                     other_version_path = os.path.join(other_user_path, other_version)
                     if dir == "results":
-                        # only the "details" folder within "results" contains files relevant to Lichen
+                        # only the "details" dir within "results" contains files relevant to Lichen
                         other_version_path = os.path.join(other_version_path, "details")
                     if not os.path.isdir(other_version_path):
                         continue


### PR DESCRIPTION
### What is the current behavior?
Currently, if a Lichen run is configured to take files from the `results` directory, all of the files under that directory or its subdirectories are taken or at least compared against the provided regex expression, while there are many files in `results` generated by Submitty when the submission is made and later when autograding is done on it.

### What is the new behavior?
Only files under `results/details` will be taken in the concatenation. This prevents instructors from getting results with many files which are irrelevant to the student submitted material if they provide regex expressions which re not specific enough. This improvement will also mean that less file name comparisons have to be made when trying to apply the regex pattern in the concatenation of submissions, but most importantly, there will be less data going through compare_hashes for every student submissions, which will reduce the complexity of the results and the runtime.

### Other information?
No dependencies, no breaking changes.