### PR TITLE
[Refactor:Plagiarism] Discard overlap with common code

### DIFF
--- a/compare_hashes/compare_hashes.cpp
+++ b/compare_hashes/compare_hashes.cpp
@@ -41,6 +41,16 @@ struct StudentRanking {
 };
 
 
+struct LichenConfig {
+  std::string semester;
+  std::string course;
+  std::string gradeable;
+  int sequence_length;
+  int threshold;
+  bool provided_code_enabled;
+}
+
+
 // =============================================================================
 // helper functions
 
@@ -101,11 +111,13 @@ int main(int argc, char* argv[]) {
   time_t overall_start, overall_end;
   time(&overall_start);
 
+
   // ===========================================================================
   // load Lichen config data
   std::ifstream lichen_config_istr("./lichen_config.json");
   assert(lichen_config_istr.good());
   nlohmann::json lichen_config = nlohmann::json::parse(lichen_config_istr);
+  LichenConfig config;
 
   // ===========================================================================
   // load config info
@@ -119,11 +131,11 @@ int main(int argc, char* argv[]) {
   assert(istr.good());
   nlohmann::json config_file_json = nlohmann::json::parse(istr);
 
-  std::string semester = config_file_json.value("semester", "ERROR");
-  std::string course = config_file_json.value("course", "ERROR");
-  std::string gradeable = config_file_json.value("gradeable", "ERROR");
-  int sequence_length = config_file_json.value("sequence_length", 1);
-  int threshold = config_file_json.value("threshold", 5);
+  config.semester = config_file_json.value("semester", "ERROR");
+  config.course = config_file_json.value("course", "ERROR");
+  config.gradeable = config_file_json.value("gradeable", "ERROR");
+  config.sequence_length = config_file_json.value("sequence_length", 1);
+  config.threshold = config_file_json.value("threshold", 5);
 
   // error checking, confirm there are hashes to work with
   boost::filesystem::path users_root_directory = lichen_gradeable_path / "users";
@@ -136,7 +148,7 @@ int main(int argc, char* argv[]) {
   // the file path where we expect to find the hashed instructor provided code file
   boost::filesystem::path provided_code_file = lichen_gradeable_path / "provided_code" / "hashes.txt";
   // if file exists in that location, the provided code mode is enabled.
-  bool provided_code_enabled = boost::filesystem::exists(provided_code_file);
+  config.provided_code_enabled = boost::filesystem::exists(provided_code_file);
   // path to prior gradeables' data
   boost::filesystem::path prior_terms_dir = lichen_gradeable_path / "other_gradeables";
 

--- a/compare_hashes/hash_location.h
+++ b/compare_hashes/hash_location.h
@@ -19,7 +19,8 @@ struct HashLocation {
   std::string source_gradeable;
 };
 
-bool operator < (const HashLocation &hl1, const HashLocation &hl2) {
+// inline keyword is necessary to prevent linker errors when multiple .cpp files include this header and are then linked
+inline bool operator < (const HashLocation &hl1, const HashLocation &hl2) {
   return hl1.student > hl2.student ||
          (hl1.student == hl2.student && hl1.version < hl2.version) ||
          (hl1.student == hl2.student && hl1.version == hl2.version && hl1.location < hl2.location);

--- a/compare_hashes/lichen_config.h
+++ b/compare_hashes/lichen_config.h
@@ -1,0 +1,13 @@
+#ifndef LICHEN_CONFIG_H
+#define LICHEN_CONFIG_H
+
+struct LichenConfig {
+    std::string semester;
+    std::string course;
+    std::string gradeable;
+    int sequence_length;
+    int threshold;
+    bool provided_code_enabled;
+};
+
+#endif

--- a/compare_hashes/submission.cpp
+++ b/compare_hashes/submission.cpp
@@ -1,7 +1,4 @@
-#include <string>
-#include <unordered_map>
 #include <map>
-#include <unordered_set>
 #include <set>
 #include <vector>
 

--- a/compare_hashes/submission.cpp
+++ b/compare_hashes/submission.cpp
@@ -1,0 +1,65 @@
+#include <string>
+#include <unordered_map>
+#include <map>
+#include <unordered_set>
+#include <set>
+#include <vector>
+
+#include "hash_location.h"
+#include "submission.h"
+
+typedef int location_in_submission;
+typedef unsigned int hash;
+typedef std::string user_id;
+typedef unsigned int version_number;
+
+float Submission::getPercentage() const {
+  return (100.0 * (suspicious_matches.size())) / hashes.size();
+}
+
+void Submission::addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location, const hash &matched_hash) {
+  // figure out if there is an overlap between this hash and a common/provided match
+  int sequence_length = config_.sequence_length;
+  for (int i = location - 1; i > location - sequence_length && i >= 0; i--) {
+    if (common_matches.find(i) != common_matches.end() || provided_matches.find(i) != provided_matches.end()) {
+      return;
+    }
+  }
+
+  // save the found match
+  suspicious_matches[location].insert(matching_location);
+  // update the students_matched container
+  students_matched[matching_location.source_gradeable][matching_location.student][matching_location.version].insert(matched_hash);
+}
+
+void Submission::addCommonMatch(location_in_submission location) {
+  // figure out if there is an overlap between this hash and a match
+  int sequence_length = config_.sequence_length;
+  for (int i = location - 1; i > location - sequence_length && i >= 0; i--) {
+    std::map<location_in_submission, std::set<HashLocation> >::const_iterator find_i = suspicious_matches.find(i);
+    // if there is an overlap, remove the suspicious match that overlaps
+    // hopefully this doesn't cause problems with other submissions thinking
+    // this hash still matches...
+    if (find_i != suspicious_matches.end()) {
+      suspicious_matches.erase(find_i);
+    }
+  }
+
+  common_matches.insert(location);
+}
+
+void Submission::addProvidedMatch(location_in_submission location) {
+  // figure out if there is an overlap between this hash and a match
+  int sequence_length = config_.sequence_length;
+  for (int i = location - 1; i > location - sequence_length && i >= 0; i--) {
+    std::map<location_in_submission, std::set<HashLocation> >::const_iterator find_i = suspicious_matches.find(i);
+    // if there is an overlap, remove the suspicious match that overlaps
+    // hopefully this doesn't cause problems with other submissions thinking
+    // this hash still matches...
+    if (find_i != suspicious_matches.end()) {
+      suspicious_matches.erase(find_i);
+    }
+  }
+
+  provided_matches.insert(location);
+}

--- a/compare_hashes/submission.h
+++ b/compare_hashes/submission.h
@@ -20,7 +20,7 @@ typedef unsigned int version_number;
 class Submission {
 public:
   // CONSTRUCTOR
-  Submission(const user_id &s, version_number v) : student_(s), version_(v) {}
+  Submission(const user_id &s, version_number v, const LichenConfig &c) : student_(s), version_(v), config_(c) {}
 
   // GETTERS
   const user_id& student() const { return student_; }
@@ -31,26 +31,18 @@ public:
   const std::set<location_in_submission>& getProvidedMatches() const { return provided_matches; }
   const std::unordered_map<std::string, std::unordered_map<user_id, std::unordered_map<version_number, std::unordered_set<hash>>>>& getStudentsMatched() const { return students_matched; }
   const std::vector<std::pair<hash, location_in_submission>> & getHashes() const { return hashes; }
-  float getPercentage() const {
-    return (100.0 * (suspicious_matches.size())) / hashes.size();
-  }
+  float getPercentage() const;
 
   // MODIFIERS
   void addHash(const hash &h, location_in_submission l) { hashes.push_back(std::make_pair(h, l)); }
-
-  void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location, const hash &matched_hash) {
-    // save the found match
-    suspicious_matches[location].insert(matching_location);
-    // update the students_matched container
-    students_matched[matching_location.source_gradeable][matching_location.student][matching_location.version].insert(matched_hash);
-  }
-
-  void addCommonMatch(location_in_submission location) { common_matches.insert(location); }
-  void addProvidedMatch(location_in_submission location) { provided_matches.insert(location); }
+  void addSuspiciousMatch(location_in_submission location, const HashLocation &matching_location, const hash &matched_hash);
+  void addCommonMatch(location_in_submission location);
+  void addProvidedMatch(location_in_submission location);
 
 private:
   user_id student_;
   version_number version_;
+  LichenConfig config_;
   std::vector<std::pair<hash, location_in_submission> > hashes;
   std::map<location_in_submission, std::set<HashLocation> > suspicious_matches;
   std::set<location_in_submission> common_matches;

--- a/compare_hashes/submission.h
+++ b/compare_hashes/submission.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "hash_location.h"
+#include "lichen_config.h"
 
 typedef int location_in_submission;
 typedef unsigned int hash;

--- a/install_lichen.sh
+++ b/install_lichen.sh
@@ -62,7 +62,7 @@ mkdir -p ${lichen_installation_dir}/tools/assignments
 #-------------------------------------------
 # compile & install the hash comparison tool
 pushd ${lichen_repository_dir}  > /dev/null
-clang++ -I ${lichen_vendor_dir} -lboost_system -lboost_filesystem -Wall -Wextra -Werror -g -O3 -flto -funroll-loops -std=c++11 compare_hashes/compare_hashes.cpp -o ${lichen_installation_dir}/bin/compare_hashes.out
+clang++ -I ${lichen_vendor_dir} -lboost_system -lboost_filesystem -Wall -Wextra -Werror -g -Ofast -flto -funroll-loops -std=c++11 compare_hashes/compare_hashes.cpp compare_hashes/submission.cpp -o ${lichen_installation_dir}/bin/compare_hashes.out
 if [ $? -ne 0 ]; then
     echo -e "ERROR: FAILED TO BUILD HASH COMPARISON TOOL\n"
     exit 1


### PR DESCRIPTION
### What is the current behavior?
It is currently possible to have matching regions which appear to be shorter than the sequence length because they are sandwiched between regions of common or provided code.  This can lead to scattered coincidental matches amongst other common code which hides true plagiarism because the ranking algorithm gives the files with highest absolute match percent the highest ranking.

### What is the new behavior?
Regions which appear to be shorter than the sequence length are removed, reducing scatter and improving results in testing on artificial data.  See attached screenshots for an example of the new behavior.  In the case of the attached screenshots, manual inspection suggests that the captured region is not true plagiarism but rather a collection of similar code which matches coincidentally.  A risk here is that true plagiarism is filtered out by this algorithm but further changes which raise the bar for code to be marked as common/provided code and improve the ranking algorithm should address these concerns.

### Other information?
Before:
<img width="659" alt="before" src="https://user-images.githubusercontent.com/16820599/133940859-7d8d1791-fa63-468f-abd8-107d73ea38f0.png">
After:
<img width="661" alt="after" src="https://user-images.githubusercontent.com/16820599/133940865-a7f2e94e-29d2-467f-97e4-e2e530f1cde3.png">

