### PR TITLE
[Bugfix:Plagiarism] Support incomplete gradeables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tools/assignments/*
 __pycache__
 tests/__pycache__
 vendor/
+cmake-build-debug/*
+.idea
+.DS_Store

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -159,11 +159,17 @@ def main():
                 continue
 
             if version_mode == "active_version":
-                # get the user's active version from their settings file
+                # get the user's active version from their settings file if it exists, else get
+                # most recent version for compatibility with early versions of Submitty
                 submissions_details_path = os.path.join(user_path, 'user_assignment_settings.json')
-                with open(submissions_details_path) as details_file:
-                    details_json = json.load(details_file)
-                    my_active_version = int(details_json["active_version"])
+                if os.path.exists(submissions_details_path):
+                    with open(submissions_details_path) as details_file:
+                        details_json = json.load(details_file)
+                        my_active_version = int(details_json["active_version"])
+                else:
+                    # get the most recent version
+                    print(sorted(os.listdir(user_path)))
+                    my_active_version = sorted(os.listdir(user_path))[-1]
 
             # loop over each version
             for version in sorted(os.listdir(user_path)):
@@ -206,13 +212,17 @@ def main():
                     continue
 
                 if version_mode == "active_version":
-                    # get the user's active version from their settings file
+                    # get the user's active version from their settings file if it exists, else get
+                    # most recent version for compatibility with early versions of Submitty
                     other_submissions_details_path = os.path.join(other_user_path,
                                                                   'user_assignment_settings.json')
-
-                    with open(other_submissions_details_path) as other_details_file:
-                        other_details_json = json.load(other_details_file)
-                        my_active_version = int(other_details_json["active_version"])
+                    if os.path.exists(other_submissions_details_path):
+                        with open(other_submissions_details_path) as other_details_file:
+                            other_details_json = json.load(other_details_file)
+                            my_active_version = int(other_details_json["active_version"])
+                    else:
+                        print(sorted(os.listdir(other_user_path))[-1])
+                        my_active_version = sorted(os.listdir(other_user_path))[-1]
 
                 # loop over each version
                 for other_version in sorted(os.listdir(other_user_path)):

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -168,7 +168,6 @@ def main():
                         my_active_version = int(details_json["active_version"])
                 else:
                     # get the most recent version
-                    print(sorted(os.listdir(user_path)))
                     my_active_version = sorted(os.listdir(user_path))[-1]
 
             # loop over each version
@@ -221,7 +220,7 @@ def main():
                             other_details_json = json.load(other_details_file)
                             my_active_version = int(other_details_json["active_version"])
                     else:
-                        print(sorted(os.listdir(other_user_path))[-1])
+                        # get the most recent version
                         my_active_version = sorted(os.listdir(other_user_path))[-1]
 
                 # loop over each version


### PR DESCRIPTION
### What is the current behavior?
On some Submitty instances, there may be missing files in some gradeables due to prior system migrations.  In the case that the `user_assignment_settings.json` file doesn't exist, Lichen should use the most recent version as the active version instead of failing.  

### What is the new behavior?
Adds support for gradeables without a `user_assignment_settings.json` file.
