### PR TITLE
[Feature:Plagiarism] Add flag to ignore C++ comments

### DIFF
--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -27,7 +27,8 @@ def tokenize(lichen_config_data, my_concatenated_file, my_tokenized_file):
 
     tokenizer = f"./{language_token_data['tokenizer']}"
 
-    if not language_token_data.get("input_as_argument"):
+    if language_token_data.get('input_as_argument') is not None and \
+       language_token_data['input_as_argument'] is not False:
         my_concatenated_file = f'< {my_concatenated_file}'
 
     if "command_args" in language_token_data:

--- a/tests/data/tokenizer/c/expected_output/output_ignore_comments.json
+++ b/tests/data/tokenizer/c/expected_output/output_ignore_comments.json
@@ -108,12 +108,6 @@
         "value": ";"
     },
     {
-        "char": 21,
-        "line": 6,
-        "type": "COMMENT",
-        "value": "// define a variable"
-    },
-    {
         "char": 5,
         "line": 7,
         "type": "KEYWORD",
@@ -156,12 +150,6 @@
         "value": ";"
     },
     {
-        "char": 39,
-        "line": 7,
-        "type": "COMMENT",
-        "value": "// define a variable and set it equal to 1"
-    },
-    {
         "char": 5,
         "line": 9,
         "type": "IDENTIFIER",
@@ -186,12 +174,6 @@
         "value": ";"
     },
     {
-        "char": 43,
-        "line": 9,
-        "type": "COMMENT",
-        "value": "// print something"
-    },
-    {
         "char": 5,
         "line": 10,
         "type": "IDENTIFIER",
@@ -214,12 +196,6 @@
         "line": 10,
         "type": "PUNCTUATION-;",
         "value": ";"
-    },
-    {
-        "char": 5,
-        "line": 12,
-        "type": "COMMENT",
-        "value": "// loop from 1 to n and multiply the previous result by i"
     },
     {
         "char": 5,
@@ -336,12 +312,6 @@
         "value": ";"
     },
     {
-        "char": 9,
-        "line": 16,
-        "type": "COMMENT",
-        "value": "/*\n        factorial += i; // this doesn't work\n        factorial -= i; // this doesn't work either\n        */"
-    },
-    {
         "char": 5,
         "line": 20,
         "type": "PUNCTUATION-}",
@@ -406,12 +376,6 @@
         "line": 22,
         "type": "PUNCTUATION-;",
         "value": ";"
-    },
-    {
-        "char": 57,
-        "line": 22,
-        "type": "COMMENT",
-        "value": "// print the result"
     },
     {
         "char": 5,

--- a/tests/data/tokenizer/c/input.cpp
+++ b/tests/data/tokenizer/c/input.cpp
@@ -3,17 +3,22 @@ using namespace std;
 
 int main()
 {
-    unsigned int n;
-    unsigned long long factorial = 1;
+    unsigned int n; // define a variable
+    unsigned long long factorial = 1; // define a variable and set it equal to 1
 
-    cout << "Enter a positive integer: ";
+    cout << "Enter a positive integer: "; // print something
     cin >> n;
 
+    // loop from 1 to n and multiply the previous result by i
     for(int i = 1; i <=n; ++i)
     {
         factorial *= i;
+        /*
+        factorial += i; // this doesn't work
+        factorial -= i; // this doesn't work either
+        */
     }
 
-    cout << "Factorial of " << n << " = " << factorial;    
+    cout << "Factorial of " << n << " = " << factorial; // print the result
     return 0;
 }

--- a/tests/unittest/tests.py
+++ b/tests/unittest/tests.py
@@ -165,6 +165,32 @@ class TestCTokenizer(unittest.TestCase):
 
             self.assertEqual(actual_output, expected_output)
 
+    def testCTokenizerIgnoreComments(self):
+        self.maxDiff = None
+
+        with TemporaryDirectory() as temp_dir:
+            input_file = Path(test_data_dir, "tokenizer", "c", "input.cpp")
+            output_file_with_comments = Path(temp_dir, "output_with_comments.json")
+            output_file_ignore_comments = Path(temp_dir, "output_ignore_comments.json")
+            expected_output_file_ignore_comments = Path(test_data_dir, "tokenizer", "c", "expected_output", "output_ignore_comments.json")
+            expected_output_file_with_comments = Path(test_data_dir, "tokenizer", "c", "expected_output", "output.json")
+
+            subprocess.check_call(f"python3 {str(Path(lichen_installation_dir, 'bin', 'c_tokenizer.py'))} {str(input_file)} --ignore_comments > {str(output_file_ignore_comments)}", shell=True)
+            subprocess.check_call(f"python3 {str(Path(lichen_installation_dir, 'bin', 'c_tokenizer.py'))} {str(input_file)} > {str(output_file_with_comments)}", shell=True)
+
+            with open(output_file_with_comments) as file:
+                actual_output_with_comments = json.load(file)
+            with open(output_file_ignore_comments) as file:
+                actual_output_ignore_comments = json.load(file)
+
+            with open(expected_output_file_with_comments) as file:
+                expected_output_with_comments = json.load(file)
+            with open(expected_output_file_ignore_comments) as file:
+                expected_output_ignore_comments = json.load(file)
+
+            self.assertEqual(actual_output_with_comments, expected_output_with_comments)
+            self.assertEqual(actual_output_ignore_comments, expected_output_ignore_comments)
+
 
 class TestPythonTokenizer(unittest.TestCase):
     def testPythonTokenizer(self):

--- a/tokenizer/c/c_tokenizer.py
+++ b/tokenizer/c/c_tokenizer.py
@@ -1,42 +1,59 @@
 import clang.cindex
 import json
-import sys
 import shutil
 import tempfile
 import os
+import argparse
 
 
-# apparently, the file name must end in .cpp (or some standard
-# c/c++ suffix to be successfully tokenized)
-
-# make a temprary filename
-tmp_cpp_file_handle, tmp_cpp_file_name = tempfile.mkstemp(suffix=".cpp")
-# copy the concatenated file to the temporary file location
-shutil.copy(sys.argv[1], tmp_cpp_file_name)
-
-if (os.path.isfile("/usr/lib/llvm-6.0/lib/libclang.so.1")):
-    clang.cindex.Config.set_library_file("/usr/lib/llvm-6.0/lib/libclang.so.1")
-elif (os.path.isfile("/usr/lib/llvm-3.8/lib/libclang-3.8.so.1")):
-    clang.cindex.Config.set_library_file("/usr/lib/llvm-3.8/lib/libclang-3.8.so.1")
-idx = clang.cindex.Index.create()
-
-# parse the input file
-parsed_data = idx.parse(tmp_cpp_file_name)
-
-# remove the temporary file
-os.remove(tmp_cpp_file_name)
-
-tokens = []
-
-for token in parsed_data.get_tokens(extent=parsed_data.cursor.extent):
-    tmp = dict()
-    tmp["line"] = int(token.location.line)
-    tmp["char"] = int(token.location.column)
-    tmp["type"] = (str(token.kind))[10:]
-    if tmp["type"] == "PUNCTUATION":
-        tmp["type"] += "-" + str(token.spelling)
-    tmp["value"] = str(token.spelling)
-    tokens.append(tmp)
+def parse_args():
+    parser = argparse.ArgumentParser(description='C Tokenizer')
+    parser.add_argument('input_file')
+    parser.add_argument('--ignore_comments', action='store_true')
+    return parser.parse_args()
 
 
-print(json.dumps(tokens, indent=4, sort_keys=True))
+def main():
+    args = parse_args()
+
+    # apparently, the file name must end in .cpp (or some standard
+    # c/c++ suffix to be successfully tokenized)
+
+    # make a temprary filename
+    tmp_cpp_file_handle, tmp_cpp_file_name = tempfile.mkstemp(suffix='.cpp')
+    # copy the concatenated file to the temporary file location
+    shutil.copy(args.input_file, tmp_cpp_file_name)
+
+    if (os.path.isfile('/usr/lib/llvm-6.0/lib/libclang.so.1')):
+        clang.cindex.Config.set_library_file('/usr/lib/llvm-6.0/lib/libclang.so.1')
+    elif (os.path.isfile('/usr/lib/llvm-3.8/lib/libclang-3.8.so.1')):
+        clang.cindex.Config.set_library_file('/usr/lib/llvm-3.8/lib/libclang-3.8.so.1')
+    idx = clang.cindex.Index.create()
+
+    # parse the input file
+    parsed_data = idx.parse(tmp_cpp_file_name)
+
+    # remove the temporary file
+    os.remove(tmp_cpp_file_name)
+
+    tokens = []
+
+    for token in parsed_data.get_tokens(extent=parsed_data.cursor.extent):
+        tmp = dict()
+        tmp['line'] = int(token.location.line)
+        tmp['char'] = int(token.location.column)
+        tmp['type'] = (str(token.kind))[10:]
+        if tmp['type'] == 'PUNCTUATION':
+            tmp['type'] += '-' + str(token.spelling)
+        tmp['value'] = str(token.spelling)
+
+        if args.ignore_comments and tmp['type'] == 'COMMENT':
+            continue
+
+        tokens.append(tmp)
+
+    print(json.dumps(tokens, indent=4, sort_keys=True))
+
+
+if __name__ == '__main__':
+    main()

--- a/tokenizer/data.json
+++ b/tokenizer/data.json
@@ -2,7 +2,7 @@
   "plaintext": {
     "tokenizer": "plaintext_tokenizer.py",
     "command_executable": "python3",
-    "input_as_argument": true,
+    "input_as_argument": false,
     "command_args": [
       "--ignore_newlines"
     ],
@@ -17,7 +17,10 @@
   "cpp": {
     "tokenizer": "c_tokenizer.py",
     "command_executable": "python3",
-    "input_as_argument": true,
+    "input_as_argument": false,
+    "command_args": [
+      "--ignore_comments"
+    ],
     "token_value": "type"
   },
   "java": {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
The various tokenizers in Lichen currently include all possible tokens for their respective languages in the output.  In real-world plagiarism, spreading comments through plagiarized code liberally is a common tactic used to try to avoid detection.  

### What is the new behavior?
This PR introduces a new `--ignore_comments` flag for the C++ tokenizer, which is on by default via the list of default arguments in `data.json`.  In doing so, the C++ tokenizer was completely refactored to better handle command-line arguments like the plaintext tokenizer.  In addition, a number of bugs relating to `data.json` parsing were fixed.  

If this feature is observed to be effective in real-world testing, similar features will be added for the other tokenizers as well.

### Other information?
This PR does not introduce any breaking changes.

`tokenize_all.py` is not tested rigorously at the moment.  The only tests for this file are the integration tests which check the basic functionality of Lichen as a whole.  Given that `data.json` was allowed to become outdated, it would probably be good to write a few basic tests to check the basic functionality of `tokenize_all.py` and verify that the various parts of `data.json` are interpreted correctly.