### PR TITLE
[Bugfix:Plagiarism] Don't list users with no matches

### DIFF
--- a/bin/similarity_ranking.py
+++ b/bin/similarity_ranking.py
@@ -163,10 +163,10 @@ def main():
     all_submissions.sort(reverse=True)
 
     # A set of all the users we've written lines for thus far (duplicates aren't allowed)
-    users_written = set('foo')
+    users_written = set()
     with open(Path(args.basepath, 'overall_ranking.txt'), 'w') as ranking_file:
         for s in all_submissions:
-            if s.user_id in users_written:
+            if s.user_id in users_written or s.total_hashes_matched == 0:
                 continue
             ranking_file.write(f"{s.user_id:10} {s.version:3} "
                                f"{s.percent_match:4.0%} {s.total_hashes_matched:>8}\n")


### PR DESCRIPTION
### What is the current behavior?
#79 Added a new Python file for ranking submissions.  The previous version of the ranking system did not list users who had submissions with no matches in the overall ranking file, but the new system does.  This causes issues on the UI when no users are matched.

### What is the new behavior?
Changes the behavior to no longer list users who have no matches in the `overall_ranking.txt` file.
