### PR TITLE
[Feature:Plagiarism] Add mime type check

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -12,6 +12,7 @@ import datetime
 import humanize
 import fnmatch
 import hashlib
+import mimetypes
 from pathlib import Path
 
 IGNORED_FILES = [
@@ -49,6 +50,12 @@ def getConcatFilesInDir(input_dir, regex_patterns):
             # exclude any files we have ignored for all submissions
             if my_file in IGNORED_FILES:
                 continue
+            
+            # check for MIME types which are not supported
+            file_type = mimetypes.guess_type(my_file)[0]
+            if file_type.endswith("/pdf") or file_type.startswith("image/"):
+                continue
+
             absolute_path = os.path.join(my_dir, my_file)
             # print a separator & filename
             with open(absolute_path, encoding='ISO-8859-1') as tmp:

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -50,7 +50,7 @@ def getConcatFilesInDir(input_dir, regex_patterns):
             # exclude any files we have ignored for all submissions
             if my_file in IGNORED_FILES:
                 continue
-            
+
             # check for MIME types which are not supported
             file_type = mimetypes.guess_type(my_file)[0]
             if file_type.endswith("/pdf") or file_type.startswith("image/"):


### PR DESCRIPTION
### What is the current behavior?
Currently, any file type that is included by the regex specified in the config is concatenated for a submission.

### What is the new behavior?
 Since we don't (and don't intend to) support direct comparison of images or pdf files, and since they are quite frequently found in student submissions, a check was added to reject these types of files and not concatenate them for a given submission.
