### PR TITLE
[Bugfix:Plagiarism] Fix missing default tokenization args

### DIFF
--- a/bin/tokenize_all.py
+++ b/bin/tokenize_all.py
@@ -33,7 +33,7 @@ def tokenize(lichen_config_data, my_concatenated_file, my_tokenized_file):
                     cli_args.append(language_token_data["command_args"][argument]["argument"])
                 else:
                     print(f"Error: Unknown tokenization argument {argument}")
-        else:  # Use the default arguments
+        elif "command_args" in language_token_data:  # Use the default arguments if they exist
             for argument in language_token_data["command_args"]:
                 if "default" in language_token_data["command_args"][argument].keys() and\
                         language_token_data["command_args"][argument]["default"]:


### PR DESCRIPTION
### What is the current behavior?
An error currently occurs when using tokenizers without default arguments such as the Python tokenizer.

### What is the new behavior?
This PR makes a simple change to fix the bug.
