### PR TITLE
[Bugfix:Plagiarism] Create Lichen directory during install

### DIFF
--- a/install_lichen.sh
+++ b/install_lichen.sh
@@ -12,6 +12,8 @@ lichen_repository_dir=/usr/local/submitty/GIT_CHECKOUT/Lichen
 lichen_installation_dir=/usr/local/submitty/Lichen
 lichen_vendor_dir=/usr/local/submitty/Lichen/vendor
 
+rm -rf "$lichen_installation_dir"
+mkdir "$lichen_installation_dir"
 cp -r "$lichen_repository_dir"/* "$lichen_installation_dir"
 
 ####################################################################################################


### PR DESCRIPTION
### What is the current behavior?
#83 accidentally introduced an issue where the top level Lichen directory (usually `/usr/local/submitty/Lichen`) was not created before beginning the install process.  The install process did not remove the directory either, meaning that the bug went undetected for anyone who had previously installed Lichen.

### What is the new behavior?
This PR modifies the install process to remove the top-level directory if it exists and then recreate it from scratch.