### PR TITLE
[Bugfix:Plagiarism] Set provided code directory permissions

### DIFF
--- a/bin/run_lichen.sh
+++ b/bin/run_lichen.sh
@@ -37,20 +37,24 @@ rm -f "${BASEPATH}/provided_code/submission.concatenated"
 rm -f "${BASEPATH}/provided_code/tokens.json"
 rm -f "${BASEPATH}/provided_code/hashes.txt"
 
-# create these directories if they don't already exist
+# Make a logs directory so we can start logging any errors
 mkdir -p "${BASEPATH}/logs"
-mkdir -p "${BASEPATH}/provided_code"
-mkdir -p "${BASEPATH}/provided_code/files"
-mkdir -p "${BASEPATH}/other_gradeables"
-mkdir -p "${BASEPATH}/users"
 
 # Run Lichen and exit if an error occurs
 {
+    # Create these directories if they don't already exist
+    mkdir -p "${BASEPATH}/provided_code"
+    [ -d "${BASEPATH}/provided_code/files" ] || {
+      # If PHP hasn't created a files directory already, create one and set the permissions
+      # to allow PHP to edit files here in the future
+      mkdir "${BASEPATH}/provided_code/files"
+      chmod g+wx "${BASEPATH}/provided_code/files" || exit 1
+    }
+    mkdir -p "${BASEPATH}/other_gradeables"
+    mkdir -p "${BASEPATH}/users"
+
     ############################################################################
     # Finish setting up Lichen run
-
-    # The default is r-x and we need PHP to be able to write if edits are made to the provided code
-    chmod g=rwxs "${BASEPATH}/provided_code/files" || exit 1
 
     cd "$(dirname "${0}")" || exit 1
 


### PR DESCRIPTION
### What is the current behavior?
The directory `.../provided_code/files` can either be created by the PHP frontend if there are provided code files, or created by Lichen and left empty if there are no provided code files uploaded by an instructor.  The method of creation determines the owner of the `.../provided_code/files` directory and its corresponding permissions.  If the directory is created by Lichen, the permissions must be changed from the default in case an instructor decides to upload provided code on a subsequent run since the PHP user would not be able to write to the directory.  The `submitty_daemon` user does not have the ability to change permissions for a directory owned by the `submitty_php` user, which is currently causing all runs with provided code to fail.

### What is the new behavior?
The permissions are now only changed when Lichen creates the directory, not every time. 

### Other information?
Since this isn't the first time we've had an issue like this, it would be nice to add an automated test for this to our CI.  I can't think of a good way to test it in way which reflects real-world use so I have left it untested for now.
