### PR TITLE
[Bugfix:Plagiarism] Add Clang to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update \
     && apt-get install -y \
        libboost-all-dev \
        python3.10 \
-       python3-pip
+       python3-pip \
+       clang-6.0
 
 # Python Dependencies
 COPY requirements.txt /Lichen/requirements.txt


### PR DESCRIPTION
### What is the current behavior?
Clang is currently used for tokenizing C and C++ code in Lichen.  During the move to containerization in #83, Clang was not added to the Dockerfile, and thus C/C++ tokenization is currently broken.

### What is the new behavior?
C/C++ tokenization works properly.
