### PR TITLE
[Bugfix:Plagiarism] Properly handle unknown file types

### DIFF
--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -54,7 +54,7 @@ def getConcatFilesInDir(input_dir, regex_patterns):
             # check for MIME types which are not supported
             file_type = mimetypes.guess_type(my_file)[0]
             if file_type is not None and \
-                (file_type.endswith("/pdf") or file_type.startswith("image/")):
+                    (file_type.endswith("/pdf") or file_type.startswith("image/")):
                 continue
 
             absolute_path = os.path.join(my_dir, my_file)

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -53,7 +53,7 @@ def getConcatFilesInDir(input_dir, regex_patterns):
 
             # check for MIME types which are not supported
             file_type = mimetypes.guess_type(my_file)[0]
-            if file_type.endswith("/pdf") or file_type.startswith("image/"):
+            if file_type is not None and (file_type.endswith("/pdf") or file_type.startswith("image/")):
                 continue
 
             absolute_path = os.path.join(my_dir, my_file)

--- a/bin/concatenate_all.py
+++ b/bin/concatenate_all.py
@@ -53,7 +53,8 @@ def getConcatFilesInDir(input_dir, regex_patterns):
 
             # check for MIME types which are not supported
             file_type = mimetypes.guess_type(my_file)[0]
-            if file_type is not None and (file_type.endswith("/pdf") or file_type.startswith("image/")):
+            if file_type is not None and \
+                (file_type.endswith("/pdf") or file_type.startswith("image/")):
                 continue
 
             absolute_path = os.path.join(my_dir, my_file)


### PR DESCRIPTION
### What is the current behavior?
The [documentation](https://docs.python.org/3/library/mimetypes.html) for `mimetypes.guess_type` indicates that the function can return `None` if the type cannot be guessed.  A return value of `None` is not properly handled, leading to Lichen crashing during the concatenation process.

### What is the new behavior?
The potential return value of `None` is handled properly.
