### PR TITLE
[Bugfix:Plagiarism] Install JDK in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y \
        libboost-all-dev \
-       python3.10 \
+       python3.8 \
        python3-pip \
-       clang-6.0
+       clang-6.0 \
+       default-jdk
 
 # Python Dependencies
 COPY requirements.txt /Lichen/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ parso==0.8.3
 clang==14.0
 
 # Java tokenization
-javac_parser==1.0.0
+javac-parser==1.0.0
 
 # turn data into human readable format
 humanize==4.3.0


### PR DESCRIPTION
### What is the current behavior?
The Java tokenizers are currently broken because the JDK is not available in the Docker container.

### What is the new behavior?
The JDK has been installed in the Docker container used to run Lichen.