### PR TITLE
[Refactor:Plagiarism] Link Boost statically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 # C++ and Python
 RUN apt-get update \
     && apt-get install -y \
-       libboost-all-dev \
        python3.8 \
        python3-pip \
        clang-6.0 \

--- a/compare_hashes/CMakeLists.txt
+++ b/compare_hashes/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(Boost REQUIRED COMPONENTS
     filesystem
 )
 
+link_libraries("-static")
+
 add_executable(Lichen
     compare_hashes.cpp
     submission.cpp

--- a/compare_hashes/CMakeLists.txt
+++ b/compare_hashes/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.16)
+project(Lichen)
+set(CMAKE_CXX_STANDARD 14)
+
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost REQUIRED COMPONENTS
+    system
+    filesystem
+)
+
+add_executable(Lichen
+    compare_hashes.cpp
+    submission.cpp
+)
+
+target_link_libraries(Lichen
+    Boost::system
+    Boost::filesystem
+)
+
+target_compile_options(Lichen PRIVATE
+    -Wall
+    -Wextra
+    -Werror
+    -g
+    -O3
+    -funroll-loops
+)
+target_link_options(Lichen PRIVATE
+    -flto
+)
+
+include_directories(/usr/local/submitty/Lichen/vendor)
+
+set_target_properties(Lichen PROPERTIES OUTPUT_NAME compare_hashes.out)

--- a/install_lichen.sh
+++ b/install_lichen.sh
@@ -54,8 +54,9 @@ fi
 ####################################################################################################
 # compile & install the hash comparison tool
 
-pushd "${lichen_repository_dir}" > /dev/null
-clang++ -I "${lichen_vendor_dir}" -lboost_system -lboost_filesystem -Wall -Wextra -Werror -g -Ofast -flto -funroll-loops -std=c++11 compare_hashes/compare_hashes.cpp compare_hashes/submission.cpp -o "${lichen_installation_dir}/compare_hashes/compare_hashes.out"
+pushd "${lichen_installation_dir}/compare_hashes" > /dev/null
+cmake "$lichen_repository_dir/compare_hashes"
+cmake --build .
 if [ "$?" -ne 0 ]; then
     echo -e "ERROR: FAILED TO BUILD HASH COMPARISON TOOL\n"
     exit 1

--- a/install_lichen.sh
+++ b/install_lichen.sh
@@ -56,7 +56,7 @@ fi
 
 pushd "${lichen_installation_dir}/compare_hashes" > /dev/null
 cmake "$lichen_repository_dir/compare_hashes"
-cmake --build .
+cmake --build . --parallel "$(nproc)"
 if [ "$?" -ne 0 ]; then
     echo -e "ERROR: FAILED TO BUILD HASH COMPARISON TOOL\n"
     exit 1


### PR DESCRIPTION
### What is the current behavior?
Boost is currently linked dynamically, which causes Lichen to be fragile when changes are made to the underlying operating system.

### What is the new behavior?
Links Boost statically, using CMake instead of a manual compilation line.  This change significantly reduced the size of the Lichen Docker image, at the expense of a much larger executable.

Image size:
```
Initial: 2.1 GB
Final: 1.5 GB
```

Executable size:
```
Initial: 3.4 MB
Final: 7.2 MB
```