### PR TITLE
[Bugfix:Plagiarism] Remove container when Lichen finishes

### DIFF
--- a/bin/run_lichen.sh
+++ b/bin/run_lichen.sh
@@ -66,7 +66,7 @@ mkdir -p "${BASEPATH}/logs"
     ############################################################################
     # Run Lichen
 
-    docker run -v "${BASEPATH}":/data -v "${LICHEN_INSTALLATION_DIR}":/Lichen submitty/lichen 
+    docker run --rm -v "${BASEPATH}":/data -v "${LICHEN_INSTALLATION_DIR}":/Lichen submitty/lichen
 
     ############################################################################
     echo "Lichen run complete: $(date +"%Y-%m-%d %H:%M:%S")"


### PR DESCRIPTION
### What is the current behavior?
Lichen currently fails to clean up the container it creates for each run.  This results in a large number of dead containers taking up space on production systems.

### What is the new behavior?
The container is deleted once the job finishes.
