### PR TITLE
[Bugfix:System] Don't use -ofast for compilation

### DIFF
--- a/install_lichen.sh
+++ b/install_lichen.sh
@@ -55,7 +55,7 @@ fi
 # compile & install the hash comparison tool
 
 pushd "${lichen_repository_dir}" > /dev/null
-clang++ -I "${lichen_vendor_dir}" -lboost_system -lboost_filesystem -Wall -Wextra -Werror -g -Ofast -flto -funroll-loops -std=c++11 compare_hashes/compare_hashes.cpp compare_hashes/submission.cpp -o "${lichen_installation_dir}/compare_hashes/compare_hashes.out"
+clang++ -I "${lichen_vendor_dir}" -lboost_system -lboost_filesystem -Wall -Wextra -Werror -g -O3 -flto -funroll-loops -std=c++11 compare_hashes/compare_hashes.cpp compare_hashes/submission.cpp -o "${lichen_installation_dir}/compare_hashes/compare_hashes.out"
 if [ "$?" -ne 0 ]; then
     echo -e "ERROR: FAILED TO BUILD HASH COMPARISON TOOL\n"
     exit 1


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
When compiling, the `-ofast` flag is used even though it is not standards compliant and higher versions of clang will report errors with `json.hpp`.

### What is the new behavior?
The `-o3` flag is used instead to ensure runtime speed is still as fast as possible without causing errors.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
