### PR TITLE
[Refactor:Developer] Update unsupported cache action

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -9,17 +9,17 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - name: Cache Pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ github.job }}-pip-${{ github.sha }}
           restore-keys: |
-              ${{ runner.os }}-${{ github.job }}-pip-
+            ${{ runner.os }}-${{ github.job }}-pip-
       - name: Install python libraries
-        run : |
+        run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install flake8 flake8-bugbear
       - name: Run python linting
-        run : python3 -m flake8
+        run: python3 -m flake8


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [ ] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
Cache v2 is used by the python linting CI job but is fully unsupported and always failed.

### What is the new behavior?
Cache v4 is used by the python linting CI job.

### Other information?
<!-- Is this a breaking change? -->
<!-- How did you test -->
